### PR TITLE
Use top-level JSON properties when deserializing cluster detail

### DIFF
--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -155,7 +155,7 @@ class CB::Client
 
   def get_cluster(id)
     resp = get "clusters/#{id}"
-    ClusterDetail.from_json resp.body, root: "cluster"
+    ClusterDetail.from_json resp.body
   rescue e : Error
     raise e unless e.resp.status == HTTP::Status::FORBIDDEN
     raise Program::Error.new "cluster #{id.colorize.t_id} does not exist, or you do not have access to it"


### PR DESCRIPTION
Traditionally, cluster details were wrapped in a `cluster:{}` subobject,
but we've since moved to preferring top-level properties instead. We
still return the subobject, but are trying to deprecate it.

Here we change CB to read properties off of the top-level JSON object.