### PR TITLE
Add `--database` flag to `scope` and `psql`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cb psql` can take `--database` to specify the name of the database to
+  connect.
+- `cb scope` can take `--database` to specify the name of the database to
+  connect.
+
 ### Fixed
 - The --ha flag for `cb create` now actually works
 

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -349,6 +349,7 @@ describe CB::Completion do
     result.should have_option "--suite"
     result.should have_option "--mandelbrot"
     result.should have_option "--tables"
+    result.should have_option "--database"
 
     result = parse("cb scope --cluster abc --suite ")
     result.should have_option "all"
@@ -362,5 +363,8 @@ describe CB::Completion do
     result = parse("cb scope --cluster abc --mandelbrot ")
     result.should have_option "--tables"
     result.should_not have_option "--mandelbrot"
+
+    result = parse("cb scope --cluster abc --database ")
+    result.should_not have_option "--database"
   end
 end

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -36,7 +36,7 @@ class CB::Completion
       return top_level
     else
       case args.first
-      when "info", "psql", "destroy", "uri"
+      when "info", "destroy", "uri"
         return info
       when "create"
         return create
@@ -44,6 +44,8 @@ class CB::Completion
         return firewall
       when "logdest"
         return logdest
+      when "psql"
+        return psql
       when "teamcert"
         return teams
       when "scope"
@@ -283,6 +285,18 @@ class CB::Completion
     return suggest
   end
 
+  def psql
+    return cluster_suggestions if @args.size == 2
+
+    if last_arg?("--database")
+      [] of String
+    end
+
+    suggest = [] of String
+    suggest << "--database\tName of database" unless has_full_flag? :database
+    return suggest
+  end
+
   def scope
     return ["--cluster\tcluster id"] if @args.size == 2
 
@@ -294,8 +308,13 @@ class CB::Completion
       return ["all\tRun all scopes", "quick\tRun some scopes"]
     end
 
+    if last_arg?("--database")
+      [] of String
+    end
+
     suggest = ::Scope::Check.all.reject { |c| @args.includes? c.flag }.map { |c| "#{c.flag}\t#{c.desc}" }
     suggest << "--suite\tRun predefined scopes" unless @args.includes? "--suite"
+    suggest << "--database\tName of database" unless @args.includes? "--database"
 
     return suggest
   end

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -2,10 +2,13 @@ require "./action"
 
 class CB::Psql < CB::Action
   property cluster_id : String?
+  property database : String?
 
   def run
     c = client.get_cluster cluster_id
     uri = client.get_cluster_default_role(cluster_id).uri
+
+    database.tap { |db| uri.path = db if db }
 
     output << "connecting to "
     team_name = print_team_slash_cluster c, output
@@ -30,6 +33,10 @@ class CB::Psql < CB::Action
   def cluster_id=(str : String)
     raise_arg_error "cluster id", str unless str =~ EID_PATTERN
     @cluster_id = str
+  end
+
+  def database=(str : String)
+    @database = str
   end
 
   private def ensure_cert(team_id) : String

--- a/src/cb/scope.cr
+++ b/src/cb/scope.cr
@@ -4,12 +4,17 @@ require "./scope_checks/*"
 class CB::Scope < CB::Action
   property cluster_id : String?
   property checks : Array(::Scope::Check.class) = [] of ::Scope::Check.class
+  property database : String?
   property suite : String?
 
   def run
     check_required_args { |missing| missing << "cluster" unless cluster_id }
 
     uri = client.get_cluster_default_role(cluster_id).uri
+
+    if database.presence
+      uri.path = database.to_s
+    end
 
     self.suite = "quick" if checks.empty? && suite.nil?
 
@@ -31,4 +36,8 @@ class CB::Scope < CB::Action
       end
     end
   end
+end
+
+def database=(str : String)
+  @database = str
 end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -77,8 +77,10 @@ op = OptionParser.new do |parser|
   end
 
   parser.on("psql", "Connect to the database using `psql`") do
-    parser.banner = "Usage: cb psql <cluster id> [-- [args for psql such as -c or -f]]"
+    parser.banner = "Usage: cb psql <cluster id> [--database] [-- [args for psql such as -c or -f]]"
     action = psql = CB::Psql.new(PROG.client)
+
+    parser.on("--database NAME", "Database name (default: postgres)") { |arg| psql.database = arg }
 
     parser.unknown_args do |args|
       psql.cluster_id = get_id_arg.call(args)
@@ -129,6 +131,7 @@ op = OptionParser.new do |parser|
     action = scope = CB::Scope.new PROG.client
     parser.on("--cluster ID", "Choose cluster") { |arg| scope.cluster_id = arg }
     parser.on("--suite <all|quick>", "Run suite of scopes (default: quick)") { |arg| scope.suite = arg }
+    parser.on("--database NAME", "Database name (default: postgres)") { |arg| scope.database = arg }
     Scope::Check.all.each do |ck|
       parser.on(ck.flag, ck.desc) { scope.checks << ck.type }
     end


### PR DESCRIPTION
These changes add the ability to specify a database name to connect when
using the `scope` and `psql` command.

The flag is setup to be optional. If not provided then it will default
to `postgres`.

```
> ./bin/cb psql --help
Usage: cb psql <cluster id> [--database] [-- [args for psql such as -c or -f]]
    -h, --help                       Show this help
    --database NAME                  Database name (default: postgres)

> ./bin/cb scope --help
Usage: cb scope <--cluster> [--(check),...]
    -h, --help                       Show this help
...
    --database NAME                  Database name (default: postgres)
...
```

Example with `psql`:

```
> ./bin/cb psql <test-cluster-id>
connecting to personal/test-cluster
psql (14.1 (Ubuntu 14.1-1.pgdg18.04+1), server 13.4)
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
Type "help" for help.

personal/test-cluster/postgres=# \q

> ./bin/cb psql <test-cluster-id> --database foo
connecting to personal/test-cluster
psql (14.1 (Ubuntu 14.1-1.pgdg18.04+1), server 13.4)
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
Type "help" for help.

personal/test-cluster/foo=# \q
```