### PR TITLE
Refactor team `roles` to use `role` from response.

### DIFF
--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -6,7 +6,7 @@ private class CompletionTestClient < CB::Client
   end
 
   def get_teams
-    [Team.new("def", "my team", false, [1])]
+    [Team.new("def", "my team", false, "manager")]
   end
 
   def get_firewall_rules(id)

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -88,19 +88,9 @@ class CB::Client
     Account.from_json resp.body
   end
 
-  jrecord Team, id : String, name : String, is_personal : Bool, roles : Array(Int32) do
-    enum Role
-      Member
-      Manager
-      Administrator
-    end
-
+  jrecord Team, id : String, name : String, is_personal : Bool, role : String? do
     def name
       is_personal ? "personal" : @name
-    end
-
-    def human_roles
-      roles.map { |i| Role.new i }
     end
   end
 

--- a/src/cb/program.cr
+++ b/src/cb/program.cr
@@ -100,7 +100,7 @@ class CB::Program
       output << "\t"
       output << team.name.ljust(name_max).colorize.t_name
       output << "\t"
-      output << team.human_roles.join ", "
+      output << team.role.to_s.titleize
       output << "\n"
     end
   end


### PR DESCRIPTION
These changes refactor the `teams` command to utilize the `role` field
found in the `teams` response as `roles` is no deprecated.

Example:

```
> ./bin/cb teams
<personal_id>      personal
<team-1-id>      adam-test-team                  Member, Manager, Administrator
<team-2-id>      <script>alert(1)</script>       Member, Manager, Administrator

> ./bin/cb teams
<personal_id>      personal
<team-1-id>      adam-test-team                  Admin
<team-2-id>      <script>alert(1)</script>       Admin
```