### PR TITLE
Add `--version` flag to `create` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cb create` can take `--version` to specify the major postgres version of the
+  new cluster. 
+
 ### Fixed
 - The --ha flag for `cb create` now actually works
 

--- a/spec/cb/cluster_create_spec.cr
+++ b/spec/cb/cluster_create_spec.cr
@@ -163,6 +163,16 @@ describe CB::ClusterCreate do
     cc.plan.should eq "my-plan3"
   end
 
+  it "checks postgres_version input" do
+    cc = make_cc
+    msg = /Invalid postgres_version/
+
+    expect_cb_error(msg) { cc.postgres_version = "<ok" }
+
+    cc.postgres_version = 14
+    cc.postgres_version.should eq 14
+  end
+
   context "fork" do
     it "fills in defaults from the source cluster" do
       cc = make_cc

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -90,6 +90,7 @@ describe CB::Completion do
     result.should have_option "--replica"
     result.should have_option "--help"
     result.should have_option "--network"
+    result.should have_option "--version"
 
     result = parse("cb create --fork ")
     result.should have_option "abc"
@@ -100,6 +101,7 @@ describe CB::Completion do
     result.should_not have_option "--team"
     result.should_not have_option "--fork"
     result.should_not have_option "--replica"
+    result.should_not have_option "--version"
 
     result = parse("cb create --fork abc --at ")
     result.should eq([] of String)
@@ -113,6 +115,7 @@ describe CB::Completion do
     result.should_not have_option "--team"
     result.should_not have_option "--fork"
     result.should_not have_option "--replica"
+    result.should_not have_option "--version"
 
     result = parse("cb create -p ")
     result.should_not have_option "--platform"
@@ -218,6 +221,22 @@ describe CB::Completion do
 
     result = parse("cb create --name \"some name\" -s  ")
     result.should have_option "512"
+
+    result = parse("cb create --version ")
+    result.should eq [] of String
+
+    result = parse("cb create -v ")
+    result.should eq [] of String
+
+    result = parse("cb create --version 14 ")
+    result.should_not be_empty
+    result.should_not have_option "--version"
+    result.should_not have_option "-v"
+
+    result = parse("cb create -v 14 ")
+    result.should_not be_empty
+    result.should_not have_option "--version"
+    result.should_not have_option "-v"
   end
 
   it "firewall" do

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -141,8 +141,8 @@ class CB::Client
     created_at : Time,
     cpu : Int32,
     is_ha : Bool,
-    major_version : Int32,
     plan_id : String,
+    major_version : Int32,
     memory : Int32,
     oldest_backup : Time?,
     provider_id : String,
@@ -171,15 +171,16 @@ class CB::Client
   # https://crunchybridgeapi.docs.apiary.io/#reference/0/clusters/post
   def create_cluster(cc)
     body = {
-      is_ha:         cc.ha,
-      major_version: 13,
-      name:          cc.name,
-      plan_id:       cc.plan,
-      provider_id:   cc.platform,
-      region_id:     cc.region,
-      storage:       cc.storage,
-      team_id:       cc.team,
-      network_id:    cc.network,
+      is_ha:               cc.ha,
+      ha:                  cc.ha,
+      name:                cc.name,
+      plan_id:             cc.plan,
+      provider_id:         cc.platform,
+      postgres_version_id: cc.postgres_version,
+      region_id:           cc.region,
+      storage:             cc.storage,
+      team_id:             cc.team,
+      network_id:          cc.network,
     }
     resp = post "clusters", body
     Cluster.from_json resp.body

--- a/src/cb/cluster_create.cr
+++ b/src/cb/cluster_create.cr
@@ -5,6 +5,7 @@ class CB::ClusterCreate < CB::Action
   property name : String?
   property plan : String?
   property platform : String?
+  property postgres_version : Int32?
   property region : String?
   property storage : Int32?
   property team : String?
@@ -85,6 +86,12 @@ class CB::ClusterCreate < CB::Action
     str = "azure" if str == "azr"
     raise_arg_error "platform", str unless str == "azure" || str == "gcp" || str == "aws"
     @platform = str
+  end
+
+  def postgres_version=(str : String)
+    self.postgres_version = str.to_i_cb
+  rescue ArgumentError
+    raise_arg_error "postgres_version", str
   end
 
   def region=(str : String)

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -114,6 +114,10 @@ class CB::Completion
       return [] of String
     end
 
+    if last_arg? "-v", "--version"
+      return [] of String
+    end
+
     cluster_suggest("--fork").tap { |s| return s if s }
     cluster_suggest("--replica").tap { |s| return s if s }
     platform_region_plan_suggest.tap { |s| return s if s }
@@ -139,6 +143,7 @@ class CB::Completion
     suggest << "--ha\thigh availability" unless has_full_flag?(:ha) || has_full_flag?(:replica)
     suggest << "--name\tcluster name" unless has_full_flag? :name
     suggest << "--network\tnetwork id" unless has_full_flag? :network
+    suggest << "--version\tmajor version" unless has_full_flag?(:version) || has_full_flag?(:fork) || has_full_flag?(:replica)
     return suggest
   end
 
@@ -340,6 +345,7 @@ class CB::Completion
     full << :fork if has_full_flag? "--fork"
     full << :replica if has_full_flag? "--replica"
     full << :network if has_full_flag? "--network"
+    full << :version if has_full_flag? "--version", "-v"
     return full
   end
 

--- a/src/cb/program.cr
+++ b/src/cb/program.cr
@@ -144,6 +144,7 @@ class CB::Program
       "state"    => c.state,
       "created"  => c.created_at.to_rfc3339,
       "plan"     => "#{c.plan_id} (#{c.memory}GiB ram, #{c.cpu}vCPU)",
+      "version"  => c.major_version,
       "storage"  => "#{c.storage}GiB",
       "ha"       => (c.is_ha ? "on" : "off"),
       "platform" => c.provider_id,

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -97,7 +97,7 @@ op = OptionParser.new do |parser|
   parser.on("create", "Create a new cluster") do
     action = create = CB::ClusterCreate.new(PROG.client)
     parser.banner = <<-EOB
-      Usage: cb create <--platform|-p> <--region|-r> <--plan> <--team|-t> [--size|-s] [--name|-n] [--ha] [--network]
+      Usage: cb create <--platform|-p> <--region|-r> <--plan> <--team|-t> [--size|-s] [--name|-n] [--version|-v] [--ha] [--network]
              cb create --fork ID [--at] [--platform|-p] [--region|-r] [--plan] [--size|-s] [--name|-n] [--ha] [--network]
              cb create --replica ID [--platform|-p] [--region|-r] [--plan] [--name|-n] [--network]
     EOB
@@ -107,6 +107,7 @@ op = OptionParser.new do |parser|
     parser.on("-n NAME", "--name NAME", "Cluster name (default: Cluster date+time)") { |arg| create.name = arg }
     parser.on("-p NAME", "--platform NAME", "Cloud provider") { |arg| create.platform = arg }
     parser.on("-r NAME", "--region NAME", "Region/Location") { |arg| create.region = arg }
+    parser.on("-v VERSION", "--version VERSION", "Postgres major version") { |arg| create.postgres_version = arg }
     parser.on("-s GiB", "--storage GiB", "Storage size (default: 100GiB, or same as source)") { |arg| create.storage = arg }
     parser.on("-t ID", "--team ID", "Team") { |arg| create.team = arg }
     parser.on("--network network", "Network") { |arg| create.network = arg }


### PR DESCRIPTION
This flag allows for specifying the postgres major version to the create
command. It is currently set to default to version 13.

Example:

```
> ./bin/cb create -p aws -r us-east-1 --plan hobby-2 --team <team_id> --version 14
...

> ./bin/cb info <cluster_id>
personal/Cluster 2022-01-20 14_09_30
     state: ready
   created: 2022-01-20T14:09:30Z
      plan: hobby-2 (2GiB ram, 1vCPU)
   version: 14
   storage: 100GiB
...
```