### PR TITLE
Add `cb restart` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cb restart` command added to restart clusters.
 
 ## [1.1.0] - 2022-01-27
 ### Added
@@ -13,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cb scope` can take `--database` to specify the name of the database to
   connect.
 - `cb create` can take `--version` to specify the major postgres version of the
-  new cluster. 
+  new cluster.
 
 ### Changed
 - `cb teams` now only shows your highest permission. "Administrator" is now "Admin"

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -386,4 +386,12 @@ describe CB::Completion do
     result = parse("cb scope --cluster abc --database ")
     result.should_not have_option "--database"
   end
+
+  it "completes restart" do
+    result = parse("cb restart ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb restart abc ")
+    result.should have_option "--confirm"
+  end
 end

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -5,10 +5,11 @@ module CB
     Log   = ::Log.for("Action")
     Error = Program::Error
 
+    property input : IO
     property output : IO
     getter client
 
-    def initialize(@client : Client, @output = STDOUT)
+    def initialize(@client : Client, @input = STDIN, @output = STDOUT)
     end
 
     def call

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -205,6 +205,10 @@ class CB::Client
     delete "clusters/#{id}"
   end
 
+  def restart_cluster(id)
+    put "clusters/#{id}/restart", ""
+  end
+
   jrecord Plan, id : String, display_name : String
   jrecord Region, id : String, display_name : String, location : String
   jrecord Provider, id : String, display_name : String,

--- a/src/cb/cluster_create.cr
+++ b/src/cb/cluster_create.cr
@@ -14,11 +14,6 @@ class CB::ClusterCreate < CB::Action
   property fork : String?
   property at : Time?
 
-  property output : IO
-
-  def initialize(@client : Client, @output = STDOUT)
-  end
-
   def pre_validate
     if (id = fork || replica)
       source = client.get_cluster id

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -46,6 +46,8 @@ class CB::Completion
         return logdest
       when "psql"
         return psql
+      when "restart"
+        return restart_cluster
       when "teamcert"
         return teams
       when "scope"
@@ -71,6 +73,7 @@ class CB::Completion
       "uri\tConnection uri",
       "create\tProvision a new cluster",
       "destroy\tDestroy a cluster",
+      "restart\tRestart a cluster",
       "firewall\tManage firewall rules",
       "psql\tInteractive psql console",
       "logdest\tManage log destinations",
@@ -302,6 +305,18 @@ class CB::Completion
     return suggest
   end
 
+  def restart_cluster
+    return cluster_suggestions if @args.size == 2
+
+    if last_arg?("--confirm")
+      [] of String
+    end
+
+    suggest = [] of String
+    suggest << "--confirm\tconfirm cluster restart" unless has_full_flag? :confirm
+    return suggest
+  end
+
   def scope
     return ["--cluster\tcluster id"] if @args.size == 2
 
@@ -365,6 +380,7 @@ class CB::Completion
     full << :replica if has_full_flag? "--replica"
     full << :network if has_full_flag? "--network"
     full << :version if has_full_flag? "--version", "-v"
+    full << :confirm if has_full_flag? "--confirm"
     return full
   end
 

--- a/src/cb/manage_firewall.cr
+++ b/src/cb/manage_firewall.cr
@@ -1,13 +1,9 @@
 class CB::ManageFirewall < CB::Action
   Error = Program::Error
 
-  property output : IO
   property cluster_id : String?
   property to_add = [] of String
   property to_remove = [] of String
-
-  def initialize(@client : Client, @output = STDOUT)
-  end
 
   def add(cidr : String)
     to_add << cidr

--- a/src/cb/restart.cr
+++ b/src/cb/restart.cr
@@ -1,0 +1,38 @@
+require "./action"
+
+class CB::Restart < CB::Action
+  property cluster_id : String?
+  property confirmed : Bool = false
+
+  def run
+    validate
+
+    c = client.get_cluster cluster_id
+
+    unless confirmed
+      output << "About to " << "restart".colorize.t_warn << " cluster " << c.name.colorize.t_name
+      output << ".\n  Type the cluster's name to confirm: "
+      response = input.gets
+
+      if c.name == response
+        confirmed = true
+      else
+        raise Error.new "Response did not match, did not restart the cluster"
+      end
+    end
+
+    client.restart_cluster cluster_id
+    output.puts "Cluster #{c.id.colorize.t_id} restarted"
+  end
+
+  def validate
+    check_required_args do |missing|
+      missing << "cluster" unless cluster_id
+    end
+  end
+
+  def cluster_id=(str : String)
+    raise_arg_error "cluster id", str unless str =~ EID_PATTERN
+    @cluster_id = str
+  end
+end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -127,6 +127,19 @@ op = OptionParser.new do |parser|
     end
   end
 
+  parser.on("restart", "Restart a cluster") do
+    action = restart = CB::Restart.new PROG.client
+    parser.banner = "Usage: cb restart <cluster id> [--confirm]"
+
+    parser.on("--confirm", "Confirm cluster restart") do
+      restart.confirmed = true
+    end
+
+    parser.unknown_args do |args|
+      restart.cluster_id = get_id_arg.call(args)
+    end
+  end
+
   parser.on("scope", "Run diagnostic queries on a cluster") do
     parser.banner = "Usage: cb scope <--cluster> [--(check),...]"
     action = scope = CB::Scope.new PROG.client


### PR DESCRIPTION
Adds a command to restart clusters.

This command requires either 1) a confirmation of the cluster name to be restarted or 2) the use of the `--confirm` flag when running the command.

Example:

```
> cb restart jlearutdxvaohdxltdbqz3lyoe
About to restart cluster test-cluster-1.
  Type the cluster's name to confirm: test-cluster-1
Cluster jlearutdxvaohdxltdbqz3lyoe restarted

> cb restart jlearutdxvaohdxltdbqz3lyoe --confirm
Cluster jlearutdxvaohdxltdbqz3lyoe restarted

> cb info jlearutdxvaohdxltdbqz3lyoe
personal/test-cluster-1
     state: restarting
...
```