### PR TITLE
Dont send date in version to sentry

### DIFF
--- a/src/cb.cr
+++ b/src/cb.cr
@@ -1,15 +1,15 @@
 module CB
   EID_PATTERN = /\A[a-z0-9]{25}[4aeimquy]\z/
 
-  VERSION       = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
-  BUILD_RELEASE = {{ flag?(:release) }}
-  BUILD_DATE    = {{ `date -u +"%Y%m%d%H%M"`.chomp.stringify }}
-  BUILD_ID      = begin
+  BUILD_RELEASE  = {{ flag?(:release) }}
+  SHARDS_VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
+  BUILD_DATE     = {{ `date -u +"%Y%m%d%H%M"`.chomp.stringify }}
+  VERSION        = begin
     {% begin %}
-      %(#{BUILD_DATE}#{"-dev" unless BUILD_RELEASE})
+      %(#{SHARDS_VERSION}#{"-unrelease" unless BUILD_RELEASE})
     {% end %}
   end
-  VERSION_STR = "cb v#{CB::VERSION} (#{CB::BUILD_ID})"
+  VERSION_STR = "cb v#{CB::VERSION} (#{CB::BUILD_DATE})"
 end
 
 require "./stdlib_ext"

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -20,7 +20,7 @@ Raven.configure do |config|
       47, 53, 56, 51, 49, 51, 51, 49,
     ])
   {% end %}
-  config.release = CB::VERSION_STR
+  config.release = CB::VERSION
   config.server_name = PROG.host
 end
 


### PR DESCRIPTION
The extra date information made sentry's "mark as fixed in version x"
feature not work right.