### PR TITLE
Add `cb detach` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `cb detach` command added to detach clusters.
 - `cb restart` command added to restart clusters.
 
 ## [1.1.0] - 2022-01-27

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -394,4 +394,12 @@ describe CB::Completion do
     result = parse("cb restart abc ")
     result.should have_option "--confirm"
   end
+
+  it "completes detach" do
+    result = parse("cb detach ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb detach abc ")
+    result.should have_option "--confirm"
+  end
 end

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -176,6 +176,10 @@ class CB::Client
     Cluster.from_json resp.body
   end
 
+  def detach_cluster(id)
+    put "clusters/#{id}/detach", ""
+  end
+
   # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridforks/post
   def fork_cluster(cc)
     resp = post "clusters/#{cc.fork}/forks", {

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -46,8 +46,8 @@ class CB::Completion
         return logdest
       when "psql"
         return psql
-      when "restart"
-        return restart_cluster
+      when "restart", "detach"
+        return restart_or_detach
       when "teamcert"
         return teams
       when "scope"
@@ -73,6 +73,7 @@ class CB::Completion
       "uri\tConnection uri",
       "create\tProvision a new cluster",
       "destroy\tDestroy a cluster",
+      "detach\tDetach a cluster",
       "restart\tRestart a cluster",
       "firewall\tManage firewall rules",
       "psql\tInteractive psql console",
@@ -305,7 +306,10 @@ class CB::Completion
     return suggest
   end
 
-  def restart_cluster
+  # `restart and `detach` are the only commands that offer `--confirm` as their
+  # own option (other than `--help`). If that expands to other commands, then
+  # perhaps we'll need to refactor this one a little to be more 'general'.
+  def restart_or_detach
     return cluster_suggestions if @args.size == 2
 
     if last_arg?("--confirm")
@@ -313,7 +317,7 @@ class CB::Completion
     end
 
     suggest = [] of String
-    suggest << "--confirm\tconfirm cluster restart" unless has_full_flag? :confirm
+    suggest << "--confirm\tconfirm cluster #{@args.first}" unless has_full_flag? :confirm
     return suggest
   end
 

--- a/src/cb/detach.cr
+++ b/src/cb/detach.cr
@@ -1,0 +1,36 @@
+require "./action"
+
+class CB::Detach < CB::Action
+  property cluster_id : String?
+  property confirmed : Bool = false
+
+  def run
+    validate
+
+    c = client.get_cluster cluster_id
+
+    unless confirmed
+      output << "About to " << "detach".colorize.t_warn << " cluster " << c.name.colorize.t_name
+      output << ".\n  Type the cluster's name to confirm: "
+      response = input.gets
+
+      if !(c.name == response)
+        raise Error.new "Response did not match, did not detach the cluster"
+      end
+    end
+
+    client.detach_cluster cluster_id
+    output.puts "Cluster #{c.id.colorize.t_id} detached."
+  end
+
+  def validate
+    check_required_args do |missing|
+      missing << "cluster" unless cluster_id
+    end
+  end
+
+  def cluster_id=(str : String)
+    raise_arg_error "cluster_id", str unless str =~ EID_PATTERN
+    @cluster_id = str
+  end
+end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -127,6 +127,19 @@ op = OptionParser.new do |parser|
     end
   end
 
+  parser.on("detach", "Detach a cluster") do
+    action = detach = CB::Detach.new PROG.client
+    parser.banner = "Usage: cb detach <cluster id>"
+
+    parser.on("--confirm", "Confirm cluster detach") do
+      detach.confirmed = true
+    end
+
+    parser.unknown_args do |args|
+      detach.cluster_id = get_id_arg.call(args)
+    end
+  end
+
   parser.on("restart", "Restart a cluster") do
     action = restart = CB::Restart.new PROG.client
     parser.banner = "Usage: cb restart <cluster id> [--confirm]"


### PR DESCRIPTION
Add command to detach read replica clusters from their primary.

This command requires that the user input the name of the cluster,
unless the `--confirm` flag is used.