### PR TITLE
Add `cb upgrade` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `cb upgrade` command added to upgrade clusters. Supports `start`, `cancel` and
+  `status` sub-commands.
 - `cb detach` command added to detach clusters.
 - `cb restart` command added to restart clusters.
 

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -1,0 +1,116 @@
+require "../spec_helper"
+
+private class ClusterUpgradeTestClient < CB::Client
+  def upgrade_cluster(arg)
+  end
+
+  def upgrade_cluster_cancel(id : String)
+  end
+
+  def upgrade_cluster_status(id : String)
+    Array(Operation).from_json "{\"operations\":[]}", root: "operations"
+  end
+
+  def get_teams
+    teams = [] of Team
+    teams << Team.new(
+      id: "teamid",
+      name: "",
+      is_personal: true,
+      role: "admin",
+    )
+  end
+
+  def get_cluster(id : String)
+    ClusterDetail.new(
+      id: id,
+      team_id: "teamid",
+      name: "source cluster",
+      state: "na",
+      created_at: Time.utc(2016, 2, 15, 10, 20, 30),
+      is_ha: false,
+      major_version: 12,
+      plan_id: "memory-4",
+      cpu: 4,
+      memory: 111,
+      oldest_backup: nil,
+      provider_id: "aws",
+      region_id: "us-east-2",
+      network_id: "nfpvoqooxzdrriu6w3bhqo55c4",
+      storage: 1234
+    )
+  end
+end
+
+describe CB::UpgradeStart do
+  it "validates that required arguments are present" do
+    action = CB::UpgradeStart.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+
+    expect_cb_error(msg) { action.validate }
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.validate.should eq true
+  end
+
+  it "#run prints cluster upgrade started" do
+    action = CB::UpgradeStart.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.confirmed = true
+
+    action.call
+
+    output.to_s.should eq "  Cluster #{action.cluster_id} upgrade started.\n"
+  end
+end
+
+describe CB::UpgradeStatus do
+  it "validates that required arguments are present" do
+    action = CB::UpgradeStatus.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+
+    expect_cb_error(msg) { action.validate }
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.validate.should eq true
+  end
+
+  it "#run no upgrades" do
+    action = CB::UpgradeStatus.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+
+    action.call
+
+    output.to_s.should eq "personal/source cluster\n  no upgrades in progress\n"
+  end
+end
+
+describe CB::UpgradeCancel do
+  it "validates that required arguments are present" do
+    action = CB::UpgradeCancel.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+
+    expect_cb_error(msg) { action.validate }
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.validate.should eq true
+  end
+
+  it "#run " do
+    action = CB::UpgradeCancel.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+
+    action.call
+
+    expected = "personal/source cluster\n"
+    expected += "  upgrade cancelled\n"
+
+    output.to_s.should eq expected
+  end
+end

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -402,4 +402,61 @@ describe CB::Completion do
     result = parse("cb detach abc ")
     result.should have_option "--confirm"
   end
+
+  it "completes upgrade" do
+    # cb upgrade
+    result = parse("cb upgrade ")
+    result.should have_option "start"
+    result.should have_option "status"
+    result.should have_option "cancel"
+
+    result = parse("cb upgrade sta")
+    result.should have_option "start"
+    result.should have_option "status"
+
+    # cb upgrade start
+    result = parse("cb upgrade start ")
+    result.should have_option "--cluster"
+    result.should have_option "--ha"
+    result.should have_option "--plan"
+    result.should have_option "--storage"
+    result.should have_option "--version"
+
+    result = parse("cb upgrade start --cluster ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb upgrade start --cluster abc ")
+    result.should_not have_option "--cluster"
+    result.should have_option "--ha"
+    result.should have_option "--plan"
+    result.should have_option "--storage"
+    result.should have_option "--version"
+
+    result = parse("cb upgrade start --ha true ")
+    result.should have_option "--cluster"
+    result.should_not have_option "--ha"
+
+    # cb upgrade cancel
+    result = parse("cb upgrade c")
+    result.should have_option "cancel"
+
+    result = parse("cb upgrade cancel ")
+    result.should have_option "--cluster"
+
+    result = parse("cb upgrade cancel --cluster ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb upgrade cancel --cluster abc ")
+    result.should eq [] of String
+
+    # cb upgrade status
+    result = parse("cb upgrade status ")
+    result.should have_option "--cluster"
+
+    result = parse("cb upgrade status --cluster ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb upgrade status --cluster abc ")
+    result.should eq [] of String
+  end
 end

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -32,5 +32,17 @@ module CB
       end
       true
     end
+
+    private def print_team_slash_cluster(c, io : IO)
+      team_name = team_name_for_cluster c
+      io << team_name << "/" if team_name
+      io << c.name.colorize.t_name << "\n"
+      team_name
+    end
+
+    private def team_name_for_cluster(c)
+      # no way to look up a single team yet
+      client.get_teams.find { |t| t.id == c.team_id }.try &.name.colorize.t_alt
+    end
   end
 end

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -88,6 +88,9 @@ class CB::Client
     Account.from_json resp.body
   end
 
+  # Upgrade operation.
+  jrecord Operation, flavor : String, state : String
+
   jrecord Team, id : String, name : String, is_personal : Bool, role : String? do
     def name
       is_personal ? "personal" : @name
@@ -193,6 +196,27 @@ class CB::Client
       network_id:  cc.network,
     }
     Cluster.from_json resp.body
+  end
+
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridupgrade/upgrade-cluster
+  def upgrade_cluster(uc)
+    resp = post "clusters/#{uc.cluster_id}/upgrade", {
+      is_ha:               uc.ha,
+      plan_id:             uc.plan,
+      postgres_version_id: uc.postgres_version,
+      storage:             uc.storage,
+    }
+    Array(Operation).from_json resp.body, root: "operations"
+  end
+
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridupgrade/get-upgrade-status
+  def upgrade_cluster_status(id)
+    resp = get "clusters/#{id}/upgrade"
+    Array(Operation).from_json resp.body, root: "operations"
+  end
+
+  def upgrade_cluster_cancel(id)
+    delete "clusters/#{id}/upgrade"
   end
 
   def replicate_cluster(cc)

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -1,0 +1,102 @@
+require "./action"
+
+abstract class CB::Upgrade < CB::Action
+  property cluster_id : String?
+  property confirmed : Bool = false
+
+  abstract def run
+
+  def validate
+    check_required_args do |missing|
+      missing << "cluster" unless cluster_id
+    end
+  end
+
+  def cluster_id=(str : String)
+    raise_arg_error "cluster id", str unless str =~ EID_PATTERN
+    @cluster_id = str
+  end
+end
+
+# Action to start cluster upgrade.
+class CB::UpgradeStart < CB::Upgrade
+  property ha : Bool?
+  property postgres_version : Int32?
+  property storage : Int32?
+  property plan : String?
+
+  def run
+    validate
+
+    c = client.get_cluster cluster_id
+
+    unless confirmed
+      output << "About to " << "upgrade".colorize.t_warn << " cluster " << c.name.colorize.t_name
+      output << ".\n  Type the cluster's name to confirm: "
+      response = input.gets
+
+      if c.name == response
+        confirmed = true
+      else
+        raise Error.new "Response did not match, did not upgrade the cluster"
+      end
+    end
+
+    client.upgrade_cluster self
+    output.puts "  Cluster #{c.id.colorize.t_id} upgrade started."
+  end
+
+  def ha=(str : String)
+    case str.downcase
+    when "true"
+      self.ha = true
+    when "false"
+      self.ha = false
+    else
+      raise_arg_error "ha", str
+    end
+  end
+
+  def postgres_version=(str : String)
+    self.postgres_version = str.to_i_cb
+  rescue ArgumentError
+    raise_arg_error "postgres_version", str
+  end
+
+  def storage=(str : String)
+    self.storage = str.to_i_cb
+  rescue ArgumentError
+    raise_arg_error "storage", str
+  end
+end
+
+# Action to cancel cluster upgrade.
+class CB::UpgradeCancel < CB::Upgrade
+  def run
+    c = client.get_cluster cluster_id
+    print_team_slash_cluster c, output
+
+    client.upgrade_cluster_cancel cluster_id
+    output << "  upgrade cancelled\n".colorize.bold
+  end
+end
+
+# Action to get the cluster upgrade status.
+class CB::UpgradeStatus < CB::Upgrade
+  def run
+    c = client.get_cluster cluster_id
+    print_team_slash_cluster c, output
+
+    operations = client.upgrade_cluster_status cluster_id
+
+    if operations.empty?
+      output << "  no upgrades in progress\n".colorize.bold
+    else
+      pad = (operations.map(&.flavor.size).max || 8) + 2
+      operations.each do |op|
+        output << op.flavor.rjust(pad).colorize.bold << ": "
+        output << op.state << "\n"
+      end
+    end
+  end
+end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -119,6 +119,39 @@ op = OptionParser.new do |parser|
     parser.on("--at TIME", "Recovery point-in-time in RFC3339 (default: now)") { |arg| create.at = arg }
   end
 
+  # Cluster Upgrade
+  parser.on("upgrade", "Manage a cluster upgrades") do
+    parser.on("start", "Start a cluster upgrade") do
+      action = upgrade = CB::UpgradeStart.new PROG.client
+      parser.banner = "Usage: cb upgrade start <--cluster>"
+
+      parser.on("--cluster ID", "Choose cluster") { |arg| upgrade.cluster_id = arg }
+      parser.on("--ha <true|false>", "High Availability") { |arg| upgrade.ha = arg }
+      parser.on("-v VERSION", "--version VERSION", "Postgres major version") { |arg| upgrade.postgres_version = arg }
+      parser.on("--plan NAME", "Plan (server vCPU+memory)") { |arg| upgrade.plan = arg }
+      parser.on("-s GiB", "--storage GiB", "Storage size") { |arg| upgrade.storage = arg }
+      parser.on("--confirm", "Confirm cluster restart") do
+        upgrade.confirmed = true
+      end
+    end
+
+    parser.on("cancel", "Cancel a cluster upgrade") do
+      action = upgrade = CB::UpgradeCancel.new PROG.client
+      parser.banner = "Usage: cb upgrade cancel <--cluster>"
+
+      parser.on("--cluster ID", "Choose cluster") { |arg| upgrade.cluster_id = arg }
+    end
+
+    parser.on("status", "Show cluster upgrade status") do
+      action = upgrade = CB::UpgradeStatus.new PROG.client
+      parser.banner = "Usage: cb upgrade status <--cluster>"
+
+      parser.on("--cluster ID", "Choose cluster") { |arg| upgrade.cluster_id = arg }
+    end
+
+    parser
+  end
+
   parser.on("destroy", "Destroy a cluster") do
     parser.banner = "Usage: cb destroy <cluster id>"
     parser.unknown_args do |args|


### PR DESCRIPTION
Adds the following commands for managing cluster upgrades:

* `cb upgrade start` starts an upgrade.
* `cb upgrade status` shows the status of cluster upgrades.
* `cb upgrade cancel` cancels cluster upgrades.