### PR TITLE
Add CLI input setter macros

### DIFF
--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -19,6 +19,53 @@ module CB
 
     abstract def run
 
+    macro eid_setter(property, description = nil)
+      property {{property}} : String?
+
+      def {{property}}=(str : String)
+        raise_arg_error {{description || property.stringify.gsub(/_/, " ")}}, str unless str =~ EID_PATTERN
+        @{{property}} = str
+      end
+    end
+
+    # For simple identifiers such as region names, or plan names where we
+    # expect only lowercase, numbers, and -
+    macro ident_setter(property)
+      property {{property}} : String?
+
+      def {{property}}=(str : String)
+        raise_arg_error {{property.stringify}}, str unless str =~ /\A[a-z0-9\-]+\z/
+        @{{property}} = str
+      end
+    end
+
+    macro i32_setter(property)
+      property {{property}} : Int32?
+
+      def {{property}}=(str : String)
+        self.{{property}} = str.to_i(base: 10, whitespace: true, underscore: true, prefix: false, strict: true, leading_zero_is_octal: false)
+      rescue ArgumentError
+        raise_arg_error {{property.stringify}}, str
+      end
+    end
+
+    # Not: unlike the other macros, this one does not create a nilable boolean,
+    # and instead creates one that defaults to false
+    macro bool_setter(property)
+      property {{property}} : Bool = false
+
+      def {{property}}=(str : String)
+        case str.downcase
+        when "true"
+          self.{{property}} = true
+        when "false"
+          self.{{property}} = false
+        else
+          raise_arg_error {{property.stringify}}, str
+        end
+      end
+    end
+
     private def raise_arg_error(field, value)
       raise Error.new "Invalid #{field.colorize.bold}: '#{value.to_s.colorize.red}'"
     end

--- a/src/cb/cluster_create.cr
+++ b/src/cb/cluster_create.cr
@@ -1,17 +1,17 @@
 require "./action"
 
 class CB::ClusterCreate < CB::Action
-  property ha : Bool = false
+  bool_setter ha
   property name : String?
-  property plan : String?
+  ident_setter plan
   property platform : String?
-  property postgres_version : Int32?
-  property region : String?
-  property storage : Int32?
-  property team : String?
-  property network : String?
-  property replica : String?
-  property fork : String?
+  i32_setter postgres_version
+  ident_setter region
+  i32_setter storage
+  eid_setter team, "team id"
+  eid_setter network, "network id"
+  eid_setter replica, "replica id"
+  eid_setter fork, "fork id"
   property at : Time?
 
   def pre_validate
@@ -54,26 +54,10 @@ class CB::ClusterCreate < CB::Action
     end
   end
 
-  def ha=(str : String)
-    case str.downcase
-    when "true"
-      self.ha = true
-    when "false"
-      self.ha = false
-    else
-      raise_arg_error "ha", str
-    end
-  end
-
   def at=(str : String)
     self.at = Time.parse_rfc3339(str).to_utc
   rescue Time::Format::Error
     raise_arg_error "at (not RFC3339)", str
-  end
-
-  def plan=(str : String)
-    raise_arg_error "plan", str unless str =~ /\A[a-z0-9\-]+\z/
-    @plan = str
   end
 
   def platform=(str : String)
@@ -81,32 +65,5 @@ class CB::ClusterCreate < CB::Action
     str = "azure" if str == "azr"
     raise_arg_error "platform", str unless str == "azure" || str == "gcp" || str == "aws"
     @platform = str
-  end
-
-  def postgres_version=(str : String)
-    self.postgres_version = str.to_i_cb
-  rescue ArgumentError
-    raise_arg_error "postgres_version", str
-  end
-
-  def region=(str : String)
-    raise_arg_error "region", str unless str =~ /\A[a-z0-9\-]+\z/
-    @region = str
-  end
-
-  def storage=(str : String)
-    self.storage = str.to_i_cb
-  rescue ArgumentError
-    raise_arg_error "storage", str
-  end
-
-  def team=(str : String)
-    raise_arg_error "team id", str unless str =~ EID_PATTERN
-    @team = str
-  end
-
-  def network=(str : String)
-    raise_arg_error "network id", str unless str =~ EID_PATTERN
-    @network = str
   end
 end

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -1,7 +1,7 @@
 require "./action"
 
 abstract class CB::Upgrade < CB::Action
-  property cluster_id : String?
+  eid_setter cluster_id
   property confirmed : Bool = false
 
   abstract def run
@@ -11,18 +11,13 @@ abstract class CB::Upgrade < CB::Action
       missing << "cluster" unless cluster_id
     end
   end
-
-  def cluster_id=(str : String)
-    raise_arg_error "cluster id", str unless str =~ EID_PATTERN
-    @cluster_id = str
-  end
 end
 
 # Action to start cluster upgrade.
 class CB::UpgradeStart < CB::Upgrade
-  property ha : Bool?
-  property postgres_version : Int32?
-  property storage : Int32?
+  bool_setter ha
+  i32_setter postgres_version
+  i32_setter storage
   property plan : String?
 
   def run
@@ -44,29 +39,6 @@ class CB::UpgradeStart < CB::Upgrade
 
     client.upgrade_cluster self
     output.puts "  Cluster #{c.id.colorize.t_id} upgrade started."
-  end
-
-  def ha=(str : String)
-    case str.downcase
-    when "true"
-      self.ha = true
-    when "false"
-      self.ha = false
-    else
-      raise_arg_error "ha", str
-    end
-  end
-
-  def postgres_version=(str : String)
-    self.postgres_version = str.to_i_cb
-  rescue ArgumentError
-    raise_arg_error "postgres_version", str
-  end
-
-  def storage=(str : String)
-    self.storage = str.to_i_cb
-  rescue ArgumentError
-    raise_arg_error "storage", str
   end
 end
 

--- a/src/cb/detach.cr
+++ b/src/cb/detach.cr
@@ -1,7 +1,7 @@
 require "./action"
 
 class CB::Detach < CB::Action
-  property cluster_id : String?
+  eid_setter cluster_id
   property confirmed : Bool = false
 
   def run
@@ -27,10 +27,5 @@ class CB::Detach < CB::Action
     check_required_args do |missing|
       missing << "cluster" unless cluster_id
     end
-  end
-
-  def cluster_id=(str : String)
-    raise_arg_error "cluster_id", str unless str =~ EID_PATTERN
-    @cluster_id = str
   end
 end

--- a/src/cb/logdest_add.cr
+++ b/src/cb/logdest_add.cr
@@ -2,9 +2,9 @@ require "./action"
 
 module CB
   class LogdestAdd < Action
-    property cluster_id : String?
+    eid_setter cluster_id
+    i32_setter port
     property host : String?
-    property port : Int32?
     property template : String?
     property desc : String?
 
@@ -22,18 +22,6 @@ module CB
         missing << "host" unless host
         missing << "template" unless template
       end
-    end
-
-    def cluster_id=(str : String)
-      raise_arg_error "cluster id", str unless str =~ EID_PATTERN
-      @cluster_id = str
-    end
-
-    def port=(str : String)
-      i = str.to_i_cb
-      self.port = i
-    rescue ArgumentError
-      raise_arg_error "port", str
     end
 
     def port=(i : Int32)

--- a/src/cb/logdest_destroy.cr
+++ b/src/cb/logdest_destroy.cr
@@ -2,8 +2,8 @@ require "./action"
 
 module CB
   class LogdestDestroy < Action
-    property cluster_id : String?
-    property logdest_id : String?
+    eid_setter cluster_id
+    eid_setter logdest_id
 
     def run
       check_required_args do |missing|
@@ -13,16 +13,6 @@ module CB
 
       client.destroy_logdest cluster_id, logdest_id
       output.puts "log destination destroyed"
-    end
-
-    def cluster_id=(str : String)
-      raise_arg_error "cluster id", str unless str =~ EID_PATTERN
-      @cluster_id = str
-    end
-
-    def logdest=(str : String)
-      raise_arg_error "logdest id", str unless str =~ EID_PATTERN
-      @logdest_id = str
     end
   end
 end

--- a/src/cb/logdest_list.cr
+++ b/src/cb/logdest_list.cr
@@ -2,7 +2,7 @@ require "./action"
 
 module CB
   class LogdestList < Action
-    property cluster_id : String?
+    eid_setter cluster_id
 
     def run
       check_required_args { |missing| missing << "cluster" unless cluster_id }

--- a/src/cb/manage_firewall.cr
+++ b/src/cb/manage_firewall.cr
@@ -1,7 +1,7 @@
 class CB::ManageFirewall < CB::Action
   Error = Program::Error
 
-  property cluster_id : String?
+  eid_setter cluster_id
   property to_add = [] of String
   property to_remove = [] of String
 

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -1,7 +1,7 @@
 require "./action"
 
 class CB::Psql < CB::Action
-  property cluster_id : String?
+  eid_setter cluster_id
   property database : String?
 
   def run
@@ -28,11 +28,6 @@ class CB::Psql < CB::Action
       "PGSSLMODE"     => "verify-ca",
       "PGSSLROOTCERT" => cert_path,
     })
-  end
-
-  def cluster_id=(str : String)
-    raise_arg_error "cluster id", str unless str =~ EID_PATTERN
-    @cluster_id = str
   end
 
   def database=(str : String)

--- a/src/cb/restart.cr
+++ b/src/cb/restart.cr
@@ -1,7 +1,7 @@
 require "./action"
 
 class CB::Restart < CB::Action
-  property cluster_id : String?
+  eid_setter cluster_id
   property confirmed : Bool = false
 
   def run
@@ -29,10 +29,5 @@ class CB::Restart < CB::Action
     check_required_args do |missing|
       missing << "cluster" unless cluster_id
     end
-  end
-
-  def cluster_id=(str : String)
-    raise_arg_error "cluster id", str unless str =~ EID_PATTERN
-    @cluster_id = str
   end
 end

--- a/src/stdlib_ext.cr
+++ b/src/stdlib_ext.cr
@@ -45,9 +45,3 @@ class URI
     parse pull.read_string
   end
 end
-
-class String
-  def to_i_cb
-    to_i(base: 10, whitespace: true, underscore: true, prefix: false, strict: true, leading_zero_is_octal: false)
-  end
-end


### PR DESCRIPTION
Use macros to define both the property and the initial format
transformation and validation for input that comes from the CLI
arguments. This unifies a lot of the copy and pasted logic, and also
adds some missed validations on eids that was easy to overlook.


@abrightwell This may (or may not) make some of the new subclassing you added in the other pr not as necessary. I've been meaning to add these macros for a while, but it was a super backburner idea. Sorry to only do this after you sent in the other PR.