### PR TITLE
Add `cb role` command and other updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `cb uri` can take `--role` to specify the name of the role to retrieve.
+- `cb role` command added to manage cluster roles. Supports `create`, `update` and `destroy`.
 - `cb upgrade` command added to upgrade clusters. Supports `start`, `cancel` and
   `status` sub-commands.
 - `cb detach` command added to detach clusters.

--- a/spec/cb/cluster_uri_spec.cr
+++ b/spec/cb/cluster_uri_spec.cr
@@ -1,0 +1,72 @@
+require "../spec_helper"
+
+private class ClusterURITestClient < CB::Client
+  ACCOUNT = Account.new(
+    id: "123",
+    name: "user",
+  )
+
+  ROLE = Role.new(
+    name: "u_" + ACCOUNT.id,
+    password: "secret",
+    uri: URI.parse "postgres://u_123:secret@localhost:5432/postgres",
+  )
+
+  def get_account
+    return ACCOUNT
+  end
+
+  property p_get_role : Proc(Role) = -> : Role { return ROLE }
+
+  def get_role(id, name)
+    return p_get_role.call
+  end
+end
+
+describe CB::ClusterURI do
+  it "ensures 'default' if role not specified" do
+    action = CB::ClusterURI.new(ClusterURITestClient.new(TEST_TOKEN))
+    action.output = IO::Memory.new
+
+    action.call
+
+    action.role_name.should eq "default"
+  end
+
+  it "#run errors on invalid role" do
+    action = CB::ClusterURI.new(ClusterURITestClient.new(TEST_TOKEN))
+    action.output = IO::Memory.new
+
+    action.role_name = "invalid"
+
+    msg = /invalid role: 'invalid'/
+
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "#run handles client errors" do
+    c = ClusterURITestClient.new(TEST_TOKEN)
+    c.p_get_role = -> : CB::Client::Role {
+      raise CB::Client::Error.new("", "",
+        HTTP::Client::Response.new(HTTP::Status::BAD_REQUEST))
+    }
+
+    action = CB::ClusterURI.new(c)
+    action.output = output = IO::Memory.new
+
+    msg = /invalid input/
+
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "#run prints uri" do
+    c = ClusterURITestClient.new(TEST_TOKEN)
+
+    action = CB::ClusterURI.new(c)
+    action.output = output = IO::Memory.new
+
+    action.call
+
+    output.to_s.should eq ClusterURITestClient::ROLE.uri.to_s
+  end
+end

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -403,6 +403,64 @@ describe CB::Completion do
     result.should have_option "--confirm"
   end
 
+  it "completes role" do
+    # cb role
+    result = parse("cb role ")
+    result.should have_option "create"
+    result.should have_option "update"
+    result.should have_option "destroy"
+
+    # cb role create
+    result = parse("cb role create ")
+    result.should have_option "--cluster"
+
+    result = parse("cb role create --cluster ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    # cb role update
+    result = parse("cb role update ")
+    result.should have_option "--cluster"
+    result.should_not have_option "--name"
+    result.should_not have_option "--read-only"
+    result.should_not have_option "--rotate-password"
+
+    result = parse("cb role update --cluster ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb role update --cluster abc ")
+    result.should_not have_option "--cluster"
+    result.should have_option "--name"
+    result.should have_option "--read-only"
+    result.should have_option "--rotate-password"
+
+    # cb role destroy
+    result = parse("cb role destroy ")
+    result.should have_option "--cluster"
+    result.should_not have_option "--name"
+
+    result = parse("cb role destroy --cluster ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb role destroy --cluster abc ")
+    result.should_not have_option "--cluster"
+    result.should have_option "--name"
+
+    result = parse("cb role destroy --name ")
+    result.should_not have_option "--name"
+    result.should eq CB::VALID_CLUSTER_ROLES.to_a
+  end
+
+  it "completes uri" do
+    result = parse("cb uri ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb uri abc ")
+    result.should have_option "--role"
+
+    result = parse("cb uri abc --role ")
+    result.should eq CB::VALID_CLUSTER_ROLES.to_a
+  end
+
   it "completes upgrade" do
     # cb upgrade
     result = parse("cb upgrade ")

--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -1,0 +1,146 @@
+require "../spec_helper"
+
+private class RoleTestClient < CB::Client
+  ACCOUNT = Account.new(
+    id: "123",
+    name: "user",
+  )
+
+  ROLE = Role.new(
+    name: "u_" + ACCOUNT.id,
+    password: "secret",
+    uri: URI.parse "postgres://u_123:secret@localhost:5432/postgres"
+  )
+
+  def get_account
+    return ACCOUNT
+  end
+
+  def create_role(id : String)
+    return ROLE
+  end
+
+  def update_role(id : String, name : String, opts)
+    return ROLE
+  end
+
+  def delete_role(id : String, name : String)
+    return ROLE
+  end
+end
+
+describe CB::RoleCreate do
+  it "validates that required arguments are present" do
+    action = CB::RoleCreate.new(RoleTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+
+    expect_cb_error(msg) { action.validate }
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.validate.should eq true
+  end
+
+  it "#run prints confirmation" do
+    action = CB::RoleCreate.new(RoleTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+
+    action.call
+
+    output.to_s.should eq "Role u_123 created on cluster #{action.cluster_id}.\n"
+  end
+end
+
+describe CB::RoleUpdate do
+  it "validates that required arguments are present" do
+    action = CB::RoleUpdate.new(RoleTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+
+    expect_cb_error(msg) { action.validate }
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.role_name = "user"
+    action.validate.should eq true
+  end
+
+  it "#run errors on invalid role" do
+    action = CB::RoleUpdate.new(RoleTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.role_name = "invalid"
+
+    msg = /invalid role '#{action.role_name}'/
+
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "#run translates 'user' role" do
+    action = CB::RoleUpdate.new(RoleTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.role_name = "user"
+
+    action.call
+
+    action.role_name.should eq "u_123"
+  end
+
+  it "#run prints confirmation" do
+    action = CB::RoleUpdate.new(RoleTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.role_name = "user"
+
+    action.call
+
+    output.to_s.should eq "Role u_123 updated on cluster #{action.cluster_id}.\n"
+  end
+end
+
+describe CB::RoleDelete do
+  it "validate that required arguments are present" do
+    action = CB::RoleDelete.new(RoleTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.role_name = "user"
+  end
+
+  it "#run errors on invalid role" do
+    action = CB::RoleDelete.new(RoleTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.role_name = "invalid"
+
+    expect_raises(CB::Program::Error, "invalid role '#{action.role_name}'") { action.call }
+  end
+
+  it "#run translates 'user' role" do
+    action = CB::RoleDelete.new(RoleTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.role_name = "user"
+
+    action.call
+
+    action.role_name.should eq "u_123"
+  end
+
+  it "#run prints confirmation" do
+    action = CB::RoleDelete.new(RoleTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.role_name = "user"
+
+    action.call
+
+    output.to_s.should eq "Role u_123 deleted from cluster #{action.cluster_id}.\n"
+  end
+end

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -49,10 +49,27 @@ module CB
       end
     end
 
-    # Not: unlike the other macros, this one does not create a nilable boolean,
+    # Note: unlike the other macros, this one does not create a nilable boolean,
     # and instead creates one that defaults to false
     macro bool_setter(property)
       property {{property}} : Bool = false
+
+      def {{property}}=(str : String)
+        case str.downcase
+        when "true"
+          self.{{property}} = true
+        when "false"
+          self.{{property}} = false
+        else
+          raise_arg_error {{property.stringify}}, str
+        end
+      end
+    end
+
+    # Nilable boolean setter. This is useful for fields where nil can have a
+    # meaningful value beyond being falesy.
+    macro bool_setter?(property)
+      property {{property}} : Bool?
 
       def {{property}}=(str : String)
         case str.downcase

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -28,12 +28,20 @@ class CB::Client
       end
     end
 
-    def unauthorized?
-      resp.status == HTTP::Status::UNAUTHORIZED
+    def bad_request?
+      resp.status == HTTP::Status::BAD_REQUEST
+    end
+
+    def forbidden?
+      resp.status == HTTP::Status::FORBIDDEN
     end
 
     def not_found?
       resp.status == HTTP::Status::NOT_FOUND
+    end
+
+    def unauthorized?
+      resp.status == HTTP::Status::UNAUTHORIZED
     end
   end
 

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -169,13 +169,6 @@ class CB::Client
     raise Program::Error.new "cluster #{id.colorize.t_id} does not exist, or you do not have access to it"
   end
 
-  jrecord Role, name : String, password : String, uri : URI
-
-  def get_cluster_default_role(id)
-    resp = get "clusters/#{id}/roles/default"
-    Role.from_json resp.body
-  end
-
   # https://crunchybridgeapi.docs.apiary.io/#reference/0/clusters/post
   def create_cluster(cc)
     body = {
@@ -297,6 +290,36 @@ class CB::Client
   def destroy_logdest(cluster_id, logdest_id)
     resp = delete "clusters/#{cluster_id}/loggers/#{logdest_id}"
     resp.body
+  end
+
+  #
+  # Cluster Roles
+  #
+
+  jrecord Role, name : String?, password : String?, uri : URI?
+
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridroles/create-role
+  def create_role(cluster_id)
+    resp = post "clusters/#{cluster_id}/roles", "{}"
+    Role.from_json resp.body
+  end
+
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrolesrolename/get-role
+  def get_role(cluster_id, role_name)
+    resp = get "clusters/#{cluster_id}/roles/#{role_name}"
+    Role.from_json resp.body
+  end
+
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrolesrolename/update-role
+  def update_role(cluster_id, role_name, ur)
+    resp = put "clusters/#{cluster_id}/roles/#{role_name}", ur
+    Role.from_json resp.body
+  end
+
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrolesrolename/delete-role
+  def delete_role(cluster_id, role_name)
+    resp = delete "clusters/#{cluster_id}/roles/#{role_name}"
+    Role.from_json resp.body
   end
 
   def get(path)

--- a/src/cb/cluster_uri.cr
+++ b/src/cb/cluster_uri.cr
@@ -2,12 +2,41 @@ require "./action"
 
 class CB::ClusterURI < CB::Action
   eid_setter cluster_id
+  property role_name : String = "default"
 
   def run
-    uri = client.get_cluster_default_role(cluster_id).uri
-    output = uri.to_s
-    pw = uri.password
-    output = output.gsub(pw, pw.colorize.black.on_black.to_s) if pw
-    puts output
+    # Ensure the role name
+    raise Error.new("invalid role: '#{@role_name}'") unless VALID_CLUSTER_ROLES.includes? @role_name
+    if @role_name == "user"
+      @role_name = "u_" + client.get_account.id
+    end
+
+    # Fetch the role.
+    role = client.get_role(cluster_id, @role_name)
+
+    # Redact the password from the result. Redaction is handled by coloring the
+    # foreground and background the same color. This benfits the user by not
+    # allowing their password to be inadvertently exposed in a TTY session. But
+    # it still allows for it to be copied and pasted without requiring any
+    # special action from the user.
+    uri = role.uri.to_s
+    unless role.password.nil?
+      pw = role.password
+      uri = uri.gsub(pw, pw.colorize.black.on_black.to_s) if pw
+    end
+
+    output << uri
+  rescue e : Client::Error
+    msg = "unknown client error."
+    case
+    when e.bad_request?
+      msg = "invalid input."
+    when e.forbidden?
+      msg = "not allowed."
+    when e.not_found?
+      msg = "role '#{@role_name}' does not exist."
+    end
+
+    raise Error.new "invalid input."
   end
 end

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -11,7 +11,7 @@ class CB::Psql < CB::Action
     database.tap { |db| uri.path = db if db }
 
     output << "connecting to "
-    team_name = print_team_slash_cluster c, output
+    team_name = print_team_slash_cluster c
 
     cert_path = ensure_cert c.team_id
     psqlrc_path = build_psqlrc c, team_name
@@ -62,17 +62,5 @@ class CB::Psql < CB::Action
     end
 
     psqlrc.path.to_s
-  end
-
-  private def print_team_slash_cluster(c, io : IO)
-    team_name = team_name_for_cluster c
-    io << team_name << "/" if team_name
-    io << c.name.colorize.t_name << "\n"
-    team_name
-  end
-
-  private def team_name_for_cluster(c)
-    # no way to look up a single team yet
-    client.get_teams.find { |t| t.id == c.team_id }.try &.name.colorize.t_alt
   end
 end

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -6,7 +6,8 @@ class CB::Psql < CB::Action
 
   def run
     c = client.get_cluster cluster_id
-    uri = client.get_cluster_default_role(cluster_id).uri
+    uri = client.get_role(cluster_id, "default").uri
+    raise Error.new "null uri" if uri.nil?
 
     database.tap { |db| uri.path = db if db }
 

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -1,0 +1,76 @@
+require "./action"
+
+module CB
+  # Valid cluster role names.
+  VALID_CLUSTER_ROLES = Set{"application", "default", "postgres", "user"}
+end
+
+abstract class CB::RoleAction < CB::Action
+  eid_setter cluster_id
+  property role_name : String?
+end
+
+# Action to create a cluster role for the calling user.
+class CB::RoleCreate < CB::RoleAction
+  def validate
+    check_required_args do |missing|
+      missing << "cluster" unless cluster_id
+    end
+  end
+
+  def run
+    validate
+
+    role = client.create_role @cluster_id
+    output << "Role #{role.name} created on cluster #{@cluster_id}.\n"
+  end
+end
+
+# Action to update a cluster role.
+class CB::RoleUpdate < CB::RoleAction
+  bool_setter? read_only
+  bool_setter? rotate_password
+
+  def validate
+    check_required_args do |missing|
+      missing << "cluster" unless cluster_id
+      missing << "name" unless role_name
+    end
+  end
+
+  def run
+    validate
+
+    # Ensure the role name
+    @role_name = "default" unless @role_name
+    raise Error.new("invalid role '#{@role_name}'") unless VALID_CLUSTER_ROLES.includes? @role_name
+    if @role_name == "user"
+      @role_name = "u_" + client.get_account.id
+    end
+
+    flavor = read_only ? "read" : "write" unless read_only.nil?
+
+    role = client.update_role @cluster_id, @role_name, {flavor: flavor, rotate_password: rotate_password}
+
+    output << "Role #{role.name} updated on cluster #{@cluster_id}.\n"
+  end
+end
+
+class CB::RoleDelete < CB::RoleAction
+  def run
+    check_required_args do |missing|
+      missing << "cluster" unless cluster_id
+      missing << "name" unless role_name
+    end
+
+    # Ensure the role name
+    @role_name = "default" unless @role_name
+    raise Error.new("invalid role '#{@role_name}'") unless VALID_CLUSTER_ROLES.includes? @role_name
+    if @role_name == "user"
+      @role_name = "u_" + client.get_account.id
+    end
+
+    role = client.delete_role @cluster_id, @role_name
+    output << "Role #{role.name} deleted from cluster #{@cluster_id}.\n"
+  end
+end

--- a/src/cb/scope.cr
+++ b/src/cb/scope.cr
@@ -37,7 +37,3 @@ class CB::Scope < CB::Action
     end
   end
 end
-
-def database=(str : String)
-  @database = str
-end

--- a/src/cb/scope.cr
+++ b/src/cb/scope.cr
@@ -10,7 +10,8 @@ class CB::Scope < CB::Action
   def run
     check_required_args { |missing| missing << "cluster" unless cluster_id }
 
-    uri = client.get_cluster_default_role(cluster_id).uri
+    uri = client.get_role(cluster_id, "default").uri
+    raise Error.new "null uri" if uri.nil?
 
     if database.presence
       uri.path = database.to_s

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -73,9 +73,11 @@ op = OptionParser.new do |parser|
     end
   end
 
-  parser.on("uri", "Display default connection URI for a cluster") do
-    parser.banner = "Usage: cb uri <cluster id>"
+  parser.on("uri", "Display connection URI for a cluster") do
+    parser.banner = "Usage: cb uri <cluster id> [--role]"
     uri = set_action ClusterURI
+
+    parser.on("--role NAME", "Role name (default: default)") { |arg| uri.role_name = arg }
 
     parser.unknown_args do |args|
       uri.cluster_id = get_id_arg.call(args)
@@ -228,6 +230,33 @@ op = OptionParser.new do |parser|
       parser.banner = "Usage: cb logdest destroy <--cluster> <--logdest>"
       parser.on("--cluster ID", "Choose cluster") { |arg| destroy.cluster_id = arg }
       parser.on("--logdest ID", "Choose log destination") { |arg| destroy.logdest_id = arg }
+    end
+  end
+
+  # Cluster Role Management
+  parser.on("role", "Manage cluster roles") do
+    parser.banner = "Usage: cb role <create|update|destroy>"
+
+    parser.on("create", "Create new role for a cluster") do
+      create = set_action RoleCreate
+      parser.banner = "Usage: cb role create <--cluster>"
+      parser.on("--cluster ID", "Choose cluster") { |arg| create.cluster_id = arg }
+    end
+
+    parser.on("update", "Update a cluster role") do
+      update = set_action RoleUpdate
+      parser.banner = "Usage: cb role update <--cluster> <--name> [--mode] [--rotate-password]"
+      parser.on("--cluster ID", "Choose cluster") { |arg| update.cluster_id = arg }
+      parser.on("--name NAME", "Role name") { |arg| update.role_name = arg }
+      parser.on("--read-only <true|false>", "Read-only") { |arg| update.read_only = arg }
+      parser.on("--rotate-password <true|false>", "Rotate password") { |arg| update.rotate_password = arg }
+    end
+
+    parser.on("destroy", "Destroy a cluster role") do
+      destroy = set_action RoleDelete
+      parser.banner = "Usage: cb role destroy <--cluster> <--name>"
+      parser.on("--cluster ID", "Choose cluster") { |arg| destroy.cluster_id = arg }
+      parser.on("--name NAME", "Role name") { |arg| destroy.role_name = arg }
     end
   end
 

--- a/src/stdlib_ext.cr
+++ b/src/stdlib_ext.cr
@@ -34,8 +34,10 @@ class IO
 end
 
 macro jrecord(name, *properties)
+  @[JSON::Serializable::Options(emit_nulls: true)]
   record({{name}}, {{*properties}}) do
     include JSON::Serializable
+
     {{yield}}
   end
 end


### PR DESCRIPTION
This PR adds the `cb role` command to allow for managing cluster roles. As well, it updates the `cb uri` command to allow for a role name to be provided via the `--role` flag.

```
> ./bin/cb role --help
Usage: cb role <create|update|destroy>
    -h, --help                       Show this help
    create                           Create new role for a cluster
    update                           Update a cluster role
    destroy                          Destroy a cluster role

> ./bin/cb role create --help
Usage: cb role create <--cluster>
    -h, --help                       Show this help
    --cluster ID                     Choose cluster

> ./bin/cb role update --help
Usage: cb role update <--cluster> <--name> [--mode] [--rotate-password]
    -h, --help                       Show this help
    --cluster ID                     Choose cluster
    --name NAME                      Role name
    --read-only <true|false>         Read-only
    --rotate-password <true|false>   Rotate password
    
> ./bin/cb role destroy --help
Usage: cb role destroy <--cluster> <--name>
    -h, --help                       Show this help
    --cluster ID                     Choose cluster
    --name NAME                      Role name
```

```
> ./bin/cb uri --help
Usage: cb uri <cluster id> [--role]
    -h, --help                       Show this help
    --role NAME                      Role name (default: default)
```