### PR TITLE
add cb rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `status` sub-commands.
 - `cb detach` command added to detach clusters.
 - `cb restart` command added to restart clusters.
+- `cb rename` command added to rename clusters.
 
 ## [1.1.0] - 2022-01-27
 ### Added

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -78,6 +78,11 @@ describe CB::Completion do
     result.should eq ["abc\tmy team/my cluster"]
   end
 
+  it "rename suggests clusters" do
+    result = parse("cb rename ")
+    result.should eq ["abc\tmy team/my cluster"]
+  end
+
   it "uri suggests clusters" do
     result = parse("cb uri ")
     result.should eq ["abc\tmy team/my cluster"]

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -192,7 +192,7 @@ class CB::Client
     id : String,
     team_id : String,
     name : String,
-    state : String,
+    state : String?,
     created_at : Time,
     cpu : Int32,
     is_ha : Bool,
@@ -272,6 +272,12 @@ class CB::Client
 
   def upgrade_cluster_cancel(id)
     delete "clusters/#{id}/upgrade"
+  end
+
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusterid/update-cluster
+  def update_cluster(cluster_id, body)
+    resp = patch "clusters/#{cluster_id}", body
+    ClusterDetail.from_json resp.body
   end
 
   def replicate_cluster(cc)

--- a/src/cb/cluster_rename.cr
+++ b/src/cb/cluster_rename.cr
@@ -1,0 +1,15 @@
+require "./action"
+
+class CB::ClusterRename < CB::Action
+  eid_setter cluster_id
+  property new_name : String?
+
+  def run
+    c = client.get_cluster cluster_id
+    print_team_slash_cluster c
+
+    new_c = client.update_cluster cluster_id, {"name" => new_name}
+
+    output << "renamed to " << new_c.name.colorize.t_name << "\n"
+  end
+end

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -44,7 +44,7 @@ class CB::Completion
       return top_level
     else
       case args.first
-      when "info", "destroy"
+      when "info", "destroy", "rename"
         return info
       when "create"
         return create
@@ -89,6 +89,7 @@ class CB::Completion
       "uri\tConnection uri",
       "create\tProvision a new cluster",
       "destroy\tDestroy a cluster",
+      "rename\tRename a cluster",
       "detach\tDetach a cluster",
       "restart\tRestart a cluster",
       "firewall\tManage firewall rules",

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -69,6 +69,20 @@ op = OptionParser.new do |parser|
     end
   end
 
+  parser.on("rename", "Change cluster name") do
+    parser.banner = "cb rename <cluster id> <new name>"
+    rename = set_action ClusterRename
+
+    parser.unknown_args do |args|
+      unless args.size == 2
+        STDERR.puts parser
+        exit 1
+      end
+      rename.cluster_id = args.first
+      rename.new_name = args.last
+    end
+  end
+
   parser.on("uri", "Display connection URI for a cluster") do
     parser.banner = "cb uri <cluster id> [--role]"
     uri = set_action ClusterURI


### PR DESCRIPTION
I noticed you couldn't rename replicas in the web ui, but it does work in the API (which it should) and that cb didn't have it yet.

Also the `state` field comes down on get but not patch? I don’t get why that is, so I made it nilable.