### PR TITLE
Add Team Member Management Commands

### DIFF
--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -528,6 +528,119 @@ describe CB::Completion do
     result.should eq [] of String
   end
 
+  it "completes team-member" do
+    # cb team-member
+    result = parse("cb team-member ")
+    result.should have_option "add"
+    result.should have_option "info"
+    result.should have_option "list"
+    result.should have_option "update"
+    result.should have_option "remove"
+
+    # cb team-member add
+    result = parse("cb team-member add ")
+    result.should have_option "--team"
+    result.should have_option "--email"
+    result.should have_option "--role"
+
+    result = parse("cb team-member add --team ")
+    result.should eq ["def\tmy team"]
+
+    result = parse("cb team-member add --email ")
+    result.should eq [] of String
+
+    result = parse("cb team-member add --role ")
+    result.should eq ["admin", "manager", "member"]
+
+    # cb team-member info
+    result = parse("cb team-member info ")
+    result.should have_option "--team"
+    result.should have_option "--account"
+    result.should have_option "--email"
+
+    result = parse("cb team-member info --team ")
+    result.should eq ["def\tmy team"]
+
+    result = parse("cb team-member info --account ")
+    result.should eq [] of String
+
+    result = parse("cb team-member info --account abc ")
+    result.should have_option "--team"
+    result.should_not have_option "--account"
+    result.should_not have_option "--email"
+
+    result = parse("cb team-member info --email test@example.com ")
+    result.should have_option "--team"
+    result.should_not have_option "--account"
+    result.should_not have_option "--email"
+
+    # cb team-member list
+    result = parse("cb team-member list ")
+    result.should have_option "--team"
+
+    result = parse("cb team-member list --team ")
+    result.should eq ["def\tmy team"]
+
+    result = parse("cb team-member list --team def ")
+    result.should eq [] of String
+
+    # cb team-member update
+    result = parse("cb team-member update ")
+    result.should have_option "--team"
+    result.should have_option "--account"
+    result.should have_option "--email"
+    result.should have_option "--role"
+
+    result = parse("cb team-member update --team ")
+    result.should eq ["def\tmy team"]
+
+    result = parse("cb team-member update --account ")
+    result.should eq [] of String
+
+    result = parse("cb team-member update --account abc ")
+    result.should_not have_option "--account"
+    result.should_not have_option "--email"
+    result.should have_option "--team"
+    result.should have_option "--role"
+
+    result = parse("cb team-member update --email ")
+    result.should eq [] of String
+
+    result = parse("cb team-member update --email test@example.com ")
+    result.should_not have_option "--account"
+    result.should_not have_option "--email"
+    result.should have_option "--team"
+    result.should have_option "--role"
+
+    result = parse("cb team-member update --role ")
+    result.should eq ["admin", "manager", "member"]
+
+    # cb team-member remove
+    result = parse("cb team-member remove ")
+    result.should have_option "--team"
+    result.should have_option "--account"
+    result.should have_option "--email"
+
+    result = parse("cb team-member remove --team ")
+    result.should eq ["def\tmy team"]
+
+    result = parse("cb team-member remove --account ")
+    result.should eq [] of String
+
+    result = parse("cb team-member remove --account abc ")
+    result.should have_option "--team"
+    result.should_not have_option "--account"
+    result.should_not have_option "--email"
+
+    result = parse("cb team-member remove --email ")
+    result.should eq [] of String
+
+    result = parse("cb team-member remove --email test@example.com ")
+    result.should have_option "--team"
+    result.should_not have_option "--account"
+    result.should_not have_option "--email"
+  end
+
   it "completes upgrade" do
     # cb upgrade
     result = parse("cb upgrade ")

--- a/spec/cb/team_member_spec.cr
+++ b/spec/cb/team_member_spec.cr
@@ -1,0 +1,219 @@
+require "../spec_helper"
+
+private class TeamMemberTestClient < CB::Client
+  MEMBERS = [
+    CB::Client::TeamMember.new(
+      id: "abc",
+      team_id: "pkdpq6yynjgjbps4otxd7il2u4",
+      account_id: "4pfqoxothfagnfdryk2og7noei",
+      role: "member",
+      email: "test@example.com",
+    ),
+  ]
+
+  def get_team(team_id)
+    return Team.new(
+      id: "pkdpq6yynjgjbps4otxd7il2u4",
+      name: "Test Team",
+      is_personal: false,
+      role: nil,
+      billing_email: nil,
+      enforce_sso: nil,
+    )
+  end
+
+  def create_team_member(team_id, params : TeamMemberCreateParams)
+    return TeamMember.new(
+      id: "",
+      team_id: team_id.to_s,
+      account_id: "abc123",
+      role: params.role,
+      email: params.email,
+    )
+  end
+
+  def get_team_member(team_id, account_id)
+    return MEMBERS[0]
+  end
+
+  def list_team_members(team_id)
+    return MEMBERS
+  end
+
+  def update_team_member(team_id, account_id, role)
+    return MEMBERS[0]
+  end
+
+  def remove_team_member(team_id, account_id)
+    return MEMBERS[0]
+  end
+end
+
+describe CB::TeamMemberAdd do
+  it "validates that required arguments are present" do
+    action = CB::TeamMemberAdd.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+    expect_cb_error(msg) { action.validate }
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.email = "test@example.com"
+    action.validate.should eq true
+
+    action.role = "some role"
+    msg = /invalid role '#{action.role}'/
+    expect_cb_error(msg) { action.validate }
+  end
+
+  it "#run prints confirmation" do
+    action = CB::TeamMemberAdd.new(TeamMemberTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.email = "test@example.com"
+
+    action.call
+
+    output.to_s.should eq "Added #{action.email} to team #{action.team_id} as role 'member'.\n"
+  end
+end
+
+describe CB::TeamMemberInfo do
+  it "validates that required arguments are present" do
+    action = CB::TeamMemberInfo.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "#run prints unknown member" do
+    action = CB::TeamMemberInfo.new(TeamMemberTestClient.new(TEST_TOKEN))
+    action.output = output = IO::Memory.new
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.email = "unknown@example.com"
+
+    action.call
+
+    expected = "Unknown team member.\n"
+    output.to_s.should eq expected
+  end
+end
+
+describe CB::TeamMemberList do
+  it "validates that required arguments are present" do
+    action = CB::TeamMemberList.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "#run" do
+    action = CB::TeamMemberList.new(TeamMemberTestClient.new(TEST_TOKEN))
+    action.output = IO::Memory.new
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.call.should be nil
+    action.output.to_s.should_not eq ""
+  end
+end
+
+describe CB::TeamMemberUpdate do
+  it "validates that required arguments are present" do
+    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "validates argument conflicts" do
+    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.account_id = "4pfqoxothfagnfdryk2og7noei"
+    action.email = "test@example.com"
+
+    msg = /Must only use '--account' or '--email' but not both./
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "#run" do
+    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
+    action.output = IO::Memory.new
+
+    # TODO (abrightwell): There's got to be a better way to test the output. For
+    # instance, more intelligently checking the value of the content, instead of
+    # just doing a simple string comparison. Perhaps revisiting this at some
+    # point would be appropriate?
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.account_id = "4pfqoxothfagnfdryk2og7noei"
+    action.call.should_not be nil
+    action.output.to_s.should_not eq ""
+
+    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
+    action.output = IO::Memory.new
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.email = "test@example.com"
+    action.call.should_not be nil
+    action.output.to_s.should_not eq ""
+  end
+
+  it "#run unknown team member" do
+    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.email = "unknown@example.com"
+
+    msg = /Unknown team member/
+    expect_cb_error(msg) { action.call }
+  end
+end
+
+describe CB::TeamMemberRemove do
+  it "validates that required arguments are present" do
+    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "validates argument conflicts" do
+    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.account_id = "4pfqoxothfagnfdryk2og7noei"
+    action.email = "test@example.com"
+
+    msg = /Must only use '--account' or '--email' but not both./
+    expect_cb_error(msg) { action.call }
+  end
+
+  it "#run" do
+    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
+    action.output = IO::Memory.new
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.account_id = "4pfqoxothfagnfdryk2og7noei"
+    action.call.should_not be nil
+    action.output.to_s.should_not eq ""
+
+    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
+    action.output = IO::Memory.new
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.email = "test@example.com"
+    action.call.should_not be nil
+    action.output.to_s.should_not eq ""
+  end
+
+  it "#run unknown team member" do
+    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
+
+    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.email = "unknown@example.com"
+
+    msg = /Unknown team member/
+    expect_cb_error(msg) { action.call }
+  end
+end

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -119,6 +119,10 @@ class CB::Client
     def name
       is_personal ? "personal" : @name
     end
+
+    def to_s(io : IO)
+      io << id.colorize.t_id << " (" << name.colorize.t_name << ")"
+    end
   end
 
   # Create a new team.
@@ -162,6 +166,61 @@ class CB::Client
   def destroy_team(id)
     resp = delete "teams/#{id}"
     Team.from_json resp.body
+  end
+
+  #
+  # Team Members
+  #
+
+  # A team member is a association of a bridge user to a bridge team.
+  jrecord TeamMember,
+    id : String,
+    team_id : String,
+    account_id : String,
+    role : String,
+    email : String
+
+  # Parameters required for adding a user to a team.
+  jrecord TeamMemberCreateParams, email : String, role : String
+
+  # Create (add) a team member.
+  #
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembers/create-team-member
+  def create_team_member(team_id, params : TeamMemberCreateParams)
+    resp = post "teams/#{team_id}/members", params
+    TeamMember.from_json resp.body
+  end
+
+  # List the memebers of a team.
+  #
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembers/list-team-members
+  def list_team_members(team_id)
+    resp = get "teams/#{team_id}/members"
+    Array(TeamMember).from_json resp.body, root: "team_members"
+  end
+
+  # Retrieve details about a team member.
+  #
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembersaccountid/get-team-member
+  def get_team_member(team_id, account_id)
+    resp = get "teams/#{team_id}/members/#{account_id}"
+    TeamMember.from_json resp.body
+  end
+
+  # Update a team member.
+  #
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembersaccountid/update-team-member
+  def update_team_member(team_id, account_id, role)
+    resp = put "teams/#{team_id}/members/#{account_id}", {role: role}
+    TeamMember.from_json resp.body
+  end
+
+  # Remove a team member from a team.
+  #
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembersaccountid/remove-team-member
+  def remove_team_member(team_id, account_id)
+    resp = delete "teams/#{team_id}/members/#{account_id}"
+    TeamMember.from_json resp.body
   end
 
   jrecord Cluster, id : String, team_id : String, name : String,

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -60,6 +60,8 @@ class CB::Completion
         return role
       when "team", "teams"
         return team
+      when "team-member"
+        return team_member
       when "teamcert"
         return teams
       when "upgrade"
@@ -84,6 +86,7 @@ class CB::Completion
       "token\tGet current API token",
       "list\tList clusters",
       "team\tManage teams",
+      "team-member\tManage a team's members",
       "teamcert\tGet team public cert",
       "info\tDetailed cluster info",
       "uri\tConnection uri",
@@ -509,6 +512,116 @@ class CB::Completion
     suggest_none
   end
 
+  #
+  # Team Member Completion
+  #
+
+  def team_member
+    case @args[1]
+    when "add"
+      team_member_add
+    when "info"
+      team_member_info
+    when "list"
+      team_member_list
+    when "update"
+      team_member_update
+    when "remove"
+      team_member_remove
+    else
+      [
+        "add\tadd a team member",
+        "list\tlist current team members",
+        "info\tshow details of a team member",
+        "update\tupdate a team member",
+        "remove\tremove a team member",
+      ]
+    end
+  end
+
+  def team_member_add
+    if last_arg?("--team")
+      return teams
+    end
+
+    if last_arg? "--email"
+      suggest_none
+    end
+
+    if last_arg?("--role")
+      return ["admin", "manager", "member"]
+    end
+
+    suggest = [] of String
+    suggest << "--team\tteam ID" unless has_full_flag? :team
+    suggest << "--email\tuser's email address" unless has_full_flag? :email
+    suggest << "--role\tteam member role" unless has_full_flag? :role
+    return suggest
+  end
+
+  def team_member_info
+    if last_arg?("--team")
+      return teams
+    end
+
+    if last_arg? "--account", "--email"
+      suggest_none
+    end
+
+    suggest = [] of String
+    suggest << "--team\tteam ID" unless has_full_flag? :team
+    suggest << "--account\tuser's account ID" unless has_full_flag?(:account) || has_full_flag?(:email)
+    suggest << "--email\tuser's email address" unless has_full_flag?(:email) || has_full_flag?(:account)
+    return suggest
+  end
+
+  def team_member_list
+    if last_arg?("--team")
+      return teams
+    end
+
+    suggest = [] of String
+    suggest << "--team\tteam ID" unless has_full_flag? :team
+    return suggest
+  end
+
+  def team_member_update
+    if last_arg?("--team")
+      return teams
+    end
+
+    if last_arg? "--account", "--email"
+      suggest_none
+    end
+
+    if last_arg?("--role")
+      return ["admin", "manager", "member"]
+    end
+
+    suggest = [] of String
+    suggest << "--team\tteam ID" unless has_full_flag? :team
+    suggest << "--account\tuser's account ID" unless has_full_flag?(:account) || has_full_flag?(:email)
+    suggest << "--email\tuser's email address" unless has_full_flag?(:email) || has_full_flag?(:account)
+    suggest << "--role\tteam member role" unless has_full_flag? :role
+    return suggest
+  end
+
+  def team_member_remove
+    if last_arg?("--team")
+      return teams
+    end
+
+    if last_arg?("--account") || last_arg?("--email")
+      suggest_none
+    end
+
+    suggest = [] of String
+    suggest << "--team\tteam ID" unless has_full_flag? :team
+    suggest << "--account\tuser's account ID" unless has_full_flag?(:account) || has_full_flag?(:email)
+    suggest << "--email\tuser's email address" unless has_full_flag?(:email) || has_full_flag?(:account)
+    return suggest
+  end
+
   def upgrade
     case @args[1]
     when "cancel"
@@ -641,6 +754,8 @@ class CB::Completion
     full << :rotate_password if has_full_flag? "--rotate-password"
     full << :enforce_sso if has_full_flag? "--enforce-sso"
     full << :billing_email if has_full_flag? "--billing-email"
+    full << :account if has_full_flag? "--account"
+    full << :email if has_full_flag? "--email"
     return full
   end
 

--- a/src/cb/team_member.cr
+++ b/src/cb/team_member.cr
@@ -1,0 +1,182 @@
+require "./action"
+
+module CB
+  TEAM_ROLE_MEMBER  = "member"
+  TEAM_ROLE_MANAGER = "manager"
+  TEAM_ROLE_ADMIN   = "admin"
+
+  # Valid team member roles.
+  VALID_TEAM_ROLES = Set{
+    TEAM_ROLE_ADMIN,
+    TEAM_ROLE_MANAGER,
+    TEAM_ROLE_MEMBER,
+  }
+end
+
+# Superclass for all TeamMember related `Action`s}.
+#
+# Provides common properties and functionality specific to team member managment
+# actions.
+abstract class CB::TeamMemberAction < CB::Action
+  eid_setter team_id
+  eid_setter account_id
+  property email : String?
+
+  private def validate_account_email
+    check_required_args do |missing|
+      missing << "team" unless team_id
+      missing << "account" unless account_id || email
+    end
+
+    raise Error.new "Must only use '--account' or '--email' but not both." if account_id && email
+  end
+
+  private def get_member_by_email(team_id, email)
+    members = client.list_team_members(team_id)
+    members.find { |tm| tm.email == email }
+  end
+
+  private def team_member_details(tm : CB::Client::TeamMember) : String
+    String.build do |str|
+      str << "Email:     \t" << tm.email.colorize.t_name << '\n'
+      str << "Team ID:   \t" << tm.team_id.colorize.t_id << '\n'
+      str << "Account ID:\t" << tm.account_id.colorize.t_id << '\n'
+      str << "Role:      \t" << tm.role.titleize
+    end
+  end
+end
+
+# Action to add an account to a team as a member.
+class CB::TeamMemberAdd < CB::TeamMemberAction
+  property role : String = TEAM_ROLE_MEMBER
+
+  def validate
+    valid = check_required_args do |missing|
+      missing << "team" unless team_id
+      missing << "email" unless email
+      missing << "role" if role.empty?
+    end
+
+    raise Error.new("invalid role '#{@role}'") unless VALID_TEAM_ROLES.includes? @role
+
+    return valid
+  end
+
+  def run
+    validate
+
+    team_member = client.create_team_member(
+      @team_id,
+      Client::TeamMemberCreateParams.new(email.to_s, role),
+    )
+
+    output << "Added " << team_member.email.colorize.green
+    output << " to team " << team_member.team_id.colorize.t_id
+    output << " as role '" << team_member.role.colorize.t_name
+    output << "'.\n"
+  end
+end
+
+# Action to list the current members of a team.
+class CB::TeamMemberList < CB::TeamMemberAction
+  def validate
+    check_required_args do |missing|
+      missing << "team" unless team_id
+    end
+  end
+
+  def run
+    validate
+
+    team_members = client.list_team_members(team_id)
+    email_max = team_members.map(&.email.size).max? || 0
+
+    # Only personal teams can be without members. So, it should be safe to
+    # assume that if the request returns an empty list that it is 'personal'
+    # team.  However, not wanting umptions to shoulder this one alone in the
+    # case that we are wrong, we'll just simply respond that the requested team
+    # doesn't have any members. Making no claims to it being personal or
+    # otherwise.  Which should be good enough in all cases, however unlikely
+    # they might be.
+    unless team_members.empty?
+      team_members.each do |member|
+        output << member.account_id.colorize.t_id << '\t'
+        output << member.email.ljust(email_max).colorize.t_name << '\t'
+        output << member.role.titleize << '\n'
+      end
+    else
+      output << "Team #{team_id.colorize.t_id} has no team members.\n"
+    end
+  end
+end
+
+# Action to show information detail about a specific team member.
+#
+# Allows for both account ID and email of the team member to be provided,
+# however, the account ID will take precedence over the email. Therefore, if
+# supplying both will raise a validation error.
+class CB::TeamMemberInfo < CB::TeamMemberAction
+  def run
+    validate_account_email
+
+    unless @account_id.nil?
+      tm = client.get_team_member(team_id, @account_id)
+    else
+      tm = get_member_by_email(team_id, email)
+    end
+
+    unless tm.nil?
+      output << team_member_details(tm) << '\n'
+    else
+      # TODO (abrightwell): move this to an error above, similar to update.
+      output << "Unknown team member.\n"
+    end
+  end
+end
+
+# Action to update a team member.
+#
+# Allows for both account ID and email of the team member to be provided,
+# however, the account ID will take precedence over the email. Therefore, if
+# supplying both will raise a validation error.
+class CB::TeamMemberUpdate < CB::TeamMemberAction
+  setter role : String?
+
+  def run
+    validate_account_email
+
+    unless @role.nil?
+      raise Error.new("invalid role '#{@role.to_s}'") unless VALID_TEAM_ROLES.includes? @role
+    end
+
+    if account_id.nil?
+      tm = get_member_by_email(team_id, @email) if account_id.nil?
+      raise Error.new "Unknown team member '#{@email}'." if tm.nil?
+      @account_id = tm.account_id
+    end
+
+    updated = client.update_team_member(team_id, @account_id, @role)
+    output << team_member_details(updated) << '\n' unless updated.nil?
+  end
+end
+
+# Action to remove a user as member from a team.
+#
+# Allows for both account ID and email of the team member to be provided,
+# however, the account ID will take precedence over the email. Therefore, if
+# supplying both will raise a validation error.
+class CB::TeamMemberRemove < CB::TeamMemberAction
+  def run
+    validate_account_email
+
+    if account_id.nil?
+      tm = get_member_by_email(team_id, @email) if account_id.nil?
+      raise Error.new "Unknown team member '#{@email}'." if tm.nil?
+      @account_id = tm.account_id
+    end
+
+    removed = client.remove_team_member(team_id, account_id)
+    team = client.get_team(team_id)
+    output << "Removed #{removed.email.colorize.t_name} from team #{team.to_s}.\n" unless removed.nil?
+  end
+end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -334,6 +334,58 @@ op = OptionParser.new do |parser|
     end
   end
 
+  #
+  # Team Member Management
+  #
+
+  parser.on("team-member", "Manage team members") do
+    parser.banner = "cb team-member <command>"
+
+    parser.on("add", "Add a team member") do
+      add = set_action TeamMemberAdd
+      parser.banner = "cb team-member add <--team> <--email> [--role]"
+
+      parser.on("--team ID", "Team ID") { |arg| add.team_id = arg }
+      parser.on("--email EMAIL", "User email address") { |arg| add.email = arg }
+      parser.on("--role ROLE", "Team member role (default: member)") { |arg| add.role = arg }
+    end
+
+    parser.on("list", "List members of a team") do
+      list = set_action TeamMemberList
+      parser.banner = "cb team-member list <--team>"
+
+      parser.on("--team ID", "Team ID") { |arg| list.team_id = arg }
+    end
+
+    parser.on("info", "Show team member details") do
+      info = set_action TeamMemberInfo
+      parser.banner = "cb team-member info <--team> <--account | --email>"
+
+      parser.on("--team ID", "Team ID") { |arg| info.team_id = arg }
+      parser.on("--account ID", "Account ID") { |arg| info.account_id = arg }
+      parser.on("--email EMAIL", "User email address") { |arg| info.email = arg }
+    end
+
+    parser.on("update", "Update a member of a team") do
+      update = set_action TeamMemberUpdate
+      parser.banner = "cb team-member update <--team> <--account | --email> [options]"
+
+      parser.on("--team ID", "Team ID") { |arg| update.team_id = arg }
+      parser.on("--account ID", "Account ID") { |arg| update.account_id = arg }
+      parser.on("--email EMAIL", "User email address") { |arg| update.email = arg }
+      parser.on("--role ROLE", "Team member role") { |arg| update.role = arg }
+    end
+
+    parser.on("remove", "Remove a member from a team") do
+      remove = set_action TeamMemberRemove
+      parser.banner = "cb team-member remove <--team> <--account | --email>"
+
+      parser.on("--team ID", "Team ID") { |arg| remove.team_id = arg }
+      parser.on("--account ID", "Account ID") { |arg| remove.account_id = arg }
+      parser.on("--email EMAIL", "User email address") { |arg| remove.email = arg }
+    end
+  end
+
   parser.on("teamcert", "Show public TLS cert for a team") do
     parser.banner = "cb teamcert <team id>"
     teamcert = set_action TeamCert


### PR DESCRIPTION
Add support for `team-member` management.

Adds command support for `team-member` management.

Implements:

`add` - add member to a team.
`info` - show details of a team member.
`list` - list current members of a team.
`update` - updates member of team - currently only supports updating role.
`remove` - removes member from team.

```
> cb team-member --help
Usage:
    cb team-member <command>

Available Commands:
    add                              Add a team member
    info                             Show team member details
    list                             List members of a team
    remove                           Remove a member from a team
    update                           Update a member of a team

Options:
    -h, --help                       Show this help
```