### PR TITLE
Update `restart` command to support service restart.

### DIFF
--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -401,6 +401,13 @@ describe CB::Completion do
 
     result = parse("cb restart abc ")
     result.should have_option "--confirm"
+    result.should have_option "--full"
+
+    result = parse("cb restart abc --full ")
+    result.should have_option "--confirm"
+
+    result = parse("cb restart abc --full --confirm ")
+    result.empty?.should be_true
   end
 
   it "completes detach" do
@@ -409,6 +416,9 @@ describe CB::Completion do
 
     result = parse("cb detach abc ")
     result.should have_option "--confirm"
+
+    result = parse "cb detach abc --confirm "
+    result.empty?.should be_true
   end
 
   it "completes role" do

--- a/spec/cb/restart_spec.cr
+++ b/spec/cb/restart_spec.cr
@@ -1,0 +1,50 @@
+require "../spec_helper"
+
+private class RestartTestClient < CB::Client
+  def get_cluster(id : String)
+    ClusterDetail.new(
+      id: id,
+      team_id: "teamid",
+      name: "source cluster",
+      state: "na",
+      created_at: Time.utc(2016, 2, 15, 10, 20, 30),
+      is_ha: false,
+      major_version: 12,
+      plan_id: "memory-4",
+      cpu: 4,
+      memory: 111,
+      oldest_backup: nil,
+      provider_id: "aws",
+      region_id: "us-east-2",
+      network_id: "nfpvoqooxzdrriu6w3bhqo55c4",
+      storage: 1234
+    )
+  end
+
+  def restart_cluster(id, service : String)
+  end
+end
+
+describe CB::Restart do
+  it "validates that required arguments are present" do
+    action = CB::Restart.new(RestartTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+    expect_cb_error(msg) { action.validate }
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.validate.should eq true
+  end
+
+  it "#run prints confirmation" do
+    action = CB::Restart.new(RestartTestClient.new(TEST_TOKEN))
+    action.output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.confirmed = true
+
+    action.call
+
+    action.output.to_s.should eq "Cluster #{action.cluster_id} restarted.\n"
+  end
+end

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -352,8 +352,9 @@ class CB::Client
     delete "clusters/#{id}"
   end
 
-  def restart_cluster(id)
-    put "clusters/#{id}/restart", ""
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrestart/restart-cluster
+  def restart_cluster(id, service : String)
+    put "clusters/#{id}/restart", {service: service}
   end
 
   jrecord Plan, id : String, display_name : String

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -48,14 +48,16 @@ class CB::Completion
         single_cluster_suggestion
       when "create"
         create
+      when "detach"
+        detach
       when "firewall"
         firewall
       when "logdest"
         logdest
       when "psql"
         psql
-      when "restart", "detach"
-        restart_or_detach
+      when "restart"
+        restart
       when "role"
         role
       when "team", "teams"
@@ -403,15 +405,17 @@ class CB::Completion
     suggest
   end
 
-  # `restart and `detach` are the only commands that offer `--confirm` as their
-  # own option (other than `--help`). If that expands to other commands, then
-  # perhaps we'll need to refactor this one a little to be more 'general'.
-  def restart_or_detach
+  def restart
     return cluster_suggestions if @args.size == 2
 
-    if last_arg?("--confirm")
-      [] of String
-    end
+    suggest = [] of String
+    suggest << "--confirm\tconfirm cluster #{@args.first}" unless has_full_flag? :confirm
+    suggest << "--full\tfull server restart" unless has_full_flag? :full
+    suggest
+  end
+
+  def detach
+    return cluster_suggestions if @args.size == 2
 
     suggest = [] of String
     suggest << "--confirm\tconfirm cluster #{@args.first}" unless has_full_flag? :confirm
@@ -758,6 +762,7 @@ class CB::Completion
     full << :billing_email if has_full_flag? "--billing-email"
     full << :account if has_full_flag? "--account"
     full << :email if has_full_flag? "--email"
+    full << :full if has_full_flag? "--full"
     full
   end
 

--- a/src/cb/restart.cr
+++ b/src/cb/restart.cr
@@ -2,7 +2,8 @@ require "./action"
 
 class CB::Restart < CB::Action
   eid_setter cluster_id
-  property confirmed : Bool = false
+  bool_setter confirmed
+  bool_setter full
 
   def run
     validate
@@ -17,12 +18,14 @@ class CB::Restart < CB::Action
       if c.name == response
         self.confirmed = true
       else
-        raise Error.new "Response did not match, did not restart the cluster"
+        raise Error.new "Response did not match, did not restart the cluster."
       end
     end
 
-    client.restart_cluster cluster_id
-    output.puts "Cluster #{c.id.colorize.t_id} restarted"
+    service = full ? "server" : "postgres"
+
+    client.restart_cluster cluster_id, service
+    output.puts "Cluster #{c.id.colorize.t_id} restarted."
   end
 
   def validate

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -194,11 +194,10 @@ op = OptionParser.new do |parser|
 
   parser.on("restart", "Restart a cluster") do
     restart = set_action Restart
-    parser.banner = "cb restart <cluster id> [--confirm]"
+    parser.banner = "cb restart <cluster id> [--confirm] [--full]"
 
-    parser.on("--confirm", "Confirm cluster restart") do
-      restart.confirmed = true
-    end
+    parser.on("--confirm", "Confirm cluster restart") { restart.confirmed = true }
+    parser.on("--full", "Full restart of server") { restart.full = true }
 
     parser.unknown_args do |args|
       restart.cluster_id = get_id_arg.call(args)


### PR DESCRIPTION
The API recently added the ability to restart both the postgres service
and the full server. Here we're adding the ability to specify which to
restart. By default, the `restart` command will restart the postgres
service. However, using the `--full` flag will perform a full restart of
the server.