### PR TITLE
Add ability to set different subdomain for logs subcommand

### DIFF
--- a/src/cb/logs.cr
+++ b/src/cb/logs.cr
@@ -6,11 +6,12 @@ require "ssh2"
 module CB
   class Logs < Action
     eid_setter cluster_id
+    property subdomain : String?
 
     def run
       tk = Tempkey.for_cluster cluster_id, client: client
 
-      host = "p.#{cluster_id}.db.postgresbridge.com"
+      host = "p.#{cluster_id}.#{subdomain}.pgbridgedev.com"
       socket = TCPSocket.new(host, 22, connect_timeout: 1)
       ssh = SSH2::Session.new(socket)
       ssh.login_with_data("cormorant", tk.private_key, tk.public_key)

--- a/src/cb/program.cr
+++ b/src/cb/program.cr
@@ -9,11 +9,13 @@ class CB::Program
   property input : IO
   property output : IO
   property host : String
+  property subdomain : String
   property creds : CB::Creds?
   property token : CB::Token?
 
-  def initialize(host = nil, @input = STDIN, @output = STDOUT)
+  def initialize(host = nil, subdomain = nil, @input = STDIN, @output = STDOUT)
     @host = host || "api.crunchybridge.com"
+    @subdomain = subdomain || "db"
     Colorize.enabled = false unless output == STDOUT && input == STDIN
   end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -8,7 +8,7 @@ Log.setup do |c|
   c.bind "*", :info, Raven::LogBackend.new(record_breadcrumbs: true)
 end
 
-PROG = CB::Program.new host: ENV["CB_HOST"]?
+PROG = CB::Program.new host: ENV["CB_HOST"]?, subdomain: ENV["CB_CLUSTER_SUBDOMAIN"]?
 
 macro set_action(cl)
   action = CB::{{cl}}.new PROG.client
@@ -219,6 +219,7 @@ op = OptionParser.new do |parser|
   parser.on("logs", "View live cluster logs") do
     parser.banner = "cb scope <cluster>"
     logs = set_action Logs
+    logs.subdomain = PROG.subdomain
 
     parser.unknown_args do |args|
       logs.cluster_id = get_id_arg.call(args)


### PR DESCRIPTION
Using `CB_CLUSTER_SUBDOMAIN`, you can specify an alternative subdomain
for the logs subcommand.
