### PR TITLE
Fix `unknown ca` issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the certificate file.
 
 ### Fixed
+- Fix `unknown ca` error with `cb psql`.
 - Fix cluster creation error after the API became stricter.
 
 ## [1.2.0] - 2022-04-07

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -56,7 +56,7 @@ class CB::Psql < CB::Action
       s << "%[%033[36m%]#{c.name}%[%033m%]"
     end
 
-    psqlrc = File.tempfile(c.id, "pslrc")
+    psqlrc = File.tempfile(c.id, "psqlrc")
     File.copy("~/.psqlrc", psqlrc.path) if File.exists?("~/.psqlrc")
     File.open(psqlrc.path, "a") do |f|
       f.puts "\\set ON_ERROR_ROLLBACK interactive"

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -26,6 +26,8 @@ class CB::Psql < CB::Action
       "PGDATABASE"    => uri.path.lchop('/'),
       "PGPORT"        => uri.port.to_s,
       "PSQLRC"        => psqlrc_path,
+      "PGSSLCERT"     => "dontuse",
+      "PGSSLKEY"      => "dontuse",
       "PGSSLMODE"     => "verify-ca",
       "PGSSLROOTCERT" => cert_path,
     })


### PR DESCRIPTION
One common issue that has come up is an `unknown ca` error with `cb
psql` when the user has `~/.postgresql/postgresql.crt` defined. ~Since
this is behavior that is internal to `psql` there really isn't much `cb`
can do to work around it. Therefore, it seems prudent to at the very
least provide some documentation or guidance on how to get around this
issue as the error message from `psql` is not very intuitive as to the
cause.~

~So, here we add a `Troubleshooting` section to the `README` file to
capture this in order to assist users that might encounter this issue
moving forward.~

As a solution, we're simply overriding the `libpq` defaults but providing a
value for the `PGSSLCERT` and `PGSSLKEY` ENVs which will be
ignored by `libpq`.
