### PR TITLE
Ensure `cb scope` uses SCRAM with channel binding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `--full` option to `cb restart` to restart the entire server.
 
+### Changed
+- Updated `cb scope` connections to utilize SCRAM with channel binding only.
+
 ## [1.3.0] - 2022-05-03
 ### Added
 - Fully respect the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)

--- a/src/cb/scope.cr
+++ b/src/cb/scope.cr
@@ -13,6 +13,11 @@ class CB::Scope < CB::Action
     uri = client.get_role(cluster_id, "default").uri
     raise Error.new "null uri" if uri.nil?
 
+    # Accept only SCRAM with Channel Binding.
+    #
+    # https://github.com/will/crystal-pg#authentication-methods
+    uri.query = "auth_methods=scram-sha-256-plus"
+
     if database.presence
       uri.path = database.to_s
     end


### PR DESCRIPTION
In an effort to improve security around `cb scope` connections, we've
updated the action to only utilize and accept SCRAM with channel binding
connections.