### PR TITLE
Make `host` configuration global to the application.

### DIFF
--- a/src/cb.cr
+++ b/src/cb.cr
@@ -1,6 +1,9 @@
 module CB
+  # Global application constants.
   EID_PATTERN = /\A[a-z0-9]{25}[4aeimquy]\z/
+  HOST        = ENV["CB_HOST"]? || "api.crunchybridge.com"
 
+  # Release constants.
   BUILD_RELEASE  = {{ flag?(:release) }}
   SHARDS_VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
   BUILD_DATE     = {{ `date -u +"%Y%m%d%H%M"`.chomp.stringify }}

--- a/src/cb/program.cr
+++ b/src/cb/program.cr
@@ -8,16 +8,16 @@ class CB::Program
 
   property input : IO
   property output : IO
-  property host : String
   property creds : CB::Creds?
   property token : CB::Token?
 
-  def initialize(host = nil, @input = STDIN, @output = STDOUT)
-    @host = host || "api.crunchybridge.com"
+  def initialize(@input = STDIN, @output = STDOUT)
     Colorize.enabled = false unless output == STDOUT && input == STDIN
   end
 
   def login
+    host = CB::HOST
+
     raise Error.new "No valid credentials found. Please login." unless output.tty?
     hint = "from https://www.crunchybridge.com/account" if host == "api.crunchybridge.com"
     output.puts "add credentials for #{host.colorize.t_name} #{hint}>"
@@ -43,14 +43,14 @@ class CB::Program
     if c = @creds
       return c
     end
-    @cred = Creds.for_host(host) || login
+    @cred = Creds.for_host(CB::HOST) || login
   end
 
   def token : CB::Token
     if t = @token
       return t
     end
-    t = Token.for_host(host) || get_token
+    t = Token.for_host(CB::HOST) || get_token
     @token = t
   end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -8,10 +8,10 @@ Log.setup do |c|
   c.bind "*", :info, Raven::LogBackend.new(record_breadcrumbs: true)
 end
 
-PROG = CB::Program.new host: ENV["CB_HOST"]?
+PROG = CB::Program.new
 
 macro set_action(cl)
-  action = CB::{{cl}}.new PROG.client
+  action = CB::{{cl}}.new PROG.client, PROG.input, PROG.output
 end
 
 def show_deprecated(msg : String)
@@ -29,7 +29,7 @@ Raven.configure do |config|
     ])
   {% end %}
   config.release = CB::VERSION
-  config.server_name = PROG.host
+  config.server_name = CB::HOST
 end
 
 action = nil


### PR DESCRIPTION
Previously, the host configuration was being read from ENV in multiple
locations and then passed to different classes and methods.  These
changes move that initialization to happen early on in startup and sets
a constant for it at the top level of the CB module. Therefore it is
only ever read/set once per invocation of the application.