### PR TITLE
Add some error handling to `cb logs`.

### DIFF
--- a/src/cb/logs.cr
+++ b/src/cb/logs.cr
@@ -23,6 +23,8 @@ module CB
       while (read_bytes = ch.read(buffer.to_slice)) > 0
         output.write buffer.to_slice[0, read_bytes]
       end
+    rescue e
+      raise Program::Error.new(cause: e)
     end
   end
 end

--- a/src/cb/program.cr
+++ b/src/cb/program.cr
@@ -4,6 +4,10 @@ require "./token"
 class CB::Program
   class Error < Exception
     property show_usage : Bool = false
+
+    def message
+      @message || @cause.try &.message
+    end
   end
 
   property input : IO


### PR DESCRIPTION
It appears that no exception handling was being done by this action.
Therefore it would output stacktraces to the user. While this doesn't
necessarily make the cause of the error easier to determine for the
user. It is at least a better look.  It would be great to tie in some
reporting on some of these, but that's for a potential future update.