### PR TITLE
Add stanza rendering to backup token output

### DIFF
--- a/spec/cb/backup_spec.cr
+++ b/spec/cb/backup_spec.cr
@@ -14,6 +14,7 @@ private class BackupTestClient < CB::Client
       BackupToken.new(
         type: "s3",
         repo_path: "/the-path",
+        stanza: "h3zwxm6bafaq3mqbgou5zj56su",
         aws: AWSBackrestCredential.new(
           s3_key: "key",
           s3_key_secret: "secret",
@@ -26,6 +27,7 @@ private class BackupTestClient < CB::Client
       BackupToken.new(
         type: "azure",
         repo_path: "/",
+        stanza: "h3zwxm6bafaq3mqbgou5zj56su",
         azure: AzureBackrestCredential.new(
           azure_account: "test_account",
           azure_key: "test_token",

--- a/src/cb/backup.cr
+++ b/src/cb/backup.cr
@@ -45,6 +45,7 @@ module CB
     jrecord BackupToken,
       type : String,
       repo_path : String,
+      stanza : String,
       aws : AWSBackrestCredential? = nil,
       azure : AzureBackrestCredential? = nil
 
@@ -89,6 +90,7 @@ module CB
 
   class BackupToken < Action
     eid_setter cluster_id
+    eid_setter stanza
     ident_setter format
 
     def run
@@ -121,6 +123,7 @@ module CB
     def output_default(token, cred)
       output << "Type:".colorize.bold << "            #{token.type}\n"
       output << "Repo Path:".colorize.bold << "       #{token.repo_path}\n"
+      output << "Stanza:".colorize.bold << "          #{token.stanza}\n"
       if cred.is_a?(Client::AWSBackrestCredential)
         output << "S3 Bucket:".colorize.bold << "       #{cred.s3_bucket}\n"
         output << "S3 Key:".colorize.bold << "          #{cred.s3_key}\n"
@@ -138,6 +141,7 @@ module CB
     end
 
     def output_pgbackrest(token, cred)
+      output << "[#{token.stanza}]\n"
       output << "repo1-type=#{token.type}\n"
       output << "repo1-path=#{token.repo_path}\n"
       if cred.is_a?(Client::AWSBackrestCredential)


### PR DESCRIPTION
Although you can get the (one and only) relevant stanza name via
`pgbackrest info`, returning the stanza from `cb` is more convenient,
and allows for scoping the configuration overriding done by the
fragment produced by `--format=pgbackrest` more helpfully on average.

See https://pgbackrest.org/user-guide-rhel.html for details on
configuration precedence.