### PR TITLE
Fix required argument check for `upgrade` actions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cb suspend` and `resume` to temporarily stop running a cluster.
 - `cb backup capture` manually starts a backup for a cluster.
 
+### Fixed
+- Fix required arguments check for `cb upgrade cancel` and `cb upgrade status`.
+
 ## [2.0.0] - 2022-05-17
 ### Added
 - `--full` option to `cb restart` to restart the entire server.

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -45,6 +45,8 @@ end
 # Action to cancel cluster upgrade.
 class CB::UpgradeCancel < CB::Upgrade
   def run
+    validate
+
     c = client.get_cluster cluster_id
     print_team_slash_cluster c
 
@@ -56,6 +58,8 @@ end
 # Action to get the cluster upgrade status.
 class CB::UpgradeStatus < CB::Upgrade
   def run
+    validate
+
     c = client.get_cluster cluster_id
     print_team_slash_cluster c
 


### PR DESCRIPTION
For `upgrade status` and `upgrade cancel` the `--cluster` argument is
required.  However, it wasn't being checked and as a result, the  error
that wasn't indicative of what really was wrong. So, we just add the
necessary validation step to the actions.