### PR TITLE
Token Action Refactor

### DIFF
--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -17,16 +17,6 @@ module CB
       Log.info { "calling #{self.class}" }
       run
     end
-  end
-
-  # APIAction performs some action utilizing the API.
-  abstract class APIAction < Action
-    property client : Client
-
-    def initialize(@client, @input = STDIN, @output = STDOUT)
-    end
-
-    abstract def run
 
     macro eid_setter(property, description = nil)
       property {{property}} : String?
@@ -105,6 +95,16 @@ module CB
       end
       true
     end
+  end
+
+  # APIAction performs some action utilizing the API.
+  abstract class APIAction < Action
+    property client : Client
+
+    def initialize(@client, @input = STDIN, @output = STDOUT)
+    end
+
+    abstract def run
 
     private def print_team_slash_cluster(c)
       team_name = team_name_for_cluster c

--- a/src/cb/token.cr
+++ b/src/cb/token.cr
@@ -1,5 +1,31 @@
 require "./cacheable"
 
+# TODO (abrightwell): We had to explicitly qualify this class name as an
+# `Action` due to conflicts with the below `Token` struct.  Would be great to
+# potentially namespace actions under `CB::Action` or something. Something
+# perhaps worth considering.
+class CB::TokenAction < CB::Action
+  enum Format
+    Default
+    Header
+  end
+
+  property token : Token
+  property format : Format = Format::Default
+
+  def initialize(@token, @input, @output)
+  end
+
+  def run
+    case @format
+    when "header"
+      output << "Authorization: Bearer #{token.token}"
+    when "default"
+      output << token.token
+    end
+  end
+end
+
 struct CB::Token
   Cacheable.include key: host
   getter host : String

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -440,10 +440,9 @@ op = OptionParser.new do |parser|
 
   parser.on("token", "Return a bearer token for use in the api") do
     parser.banner = "cb token [-H]"
-    action = ->{ puts PROG.token.token }
-    parser.on("-H", "Authorization header format") do
-      action = ->{ puts "Authorization: Bearer #{PROG.token.token}" }
-    end
+    token = action = CB::TokenAction.new PROG.token, PROG.input, PROG.output
+
+    parser.on("-H", "Authorization header format") { token.format = CB::TokenAction::Format::Header }
   end
 
   parser.on("version", "Show the version") do


### PR DESCRIPTION
Two things here:

* Pull up the `Action` setter macros to the base `Action` class to make them available to all `Action`s.
* Move the `cb token` command from a `Proc` to an `Action`.

This does not change any functionality.  This is just another step in the direction of organizing the code a bit more.