### PR TITLE
Add `cb logout` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cb logout` to logout a user from the CLI.
+
 
 ## [2.1.0] - 2022-06-03
 ### Added

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -87,6 +87,7 @@ class CB::Completion
       "--help\tShow help and usage",
       "version\tShow version information",
       "login\tStore API key",
+      "logout\tRemove stored API key and token",
       "token\tGet current API token",
       "list\tList clusters",
       "team\tManage teams",
@@ -111,7 +112,7 @@ class CB::Completion
     if @client
       options
     else
-      options.first 3
+      options.first 4
     end
   end
 

--- a/src/cb/creds.cr
+++ b/src/cb/creds.cr
@@ -34,4 +34,8 @@ struct CB::Creds
   def delete
     File.delete CONFIG/host
   end
+
+  def self.delete(host)
+    File.delete(CONFIG/host) if File.exists?(CONFIG/host)
+  end
 end

--- a/src/cb/logout.cr
+++ b/src/cb/logout.cr
@@ -1,0 +1,10 @@
+require "./action"
+
+module CB
+  class Logout < Action
+    def run
+      Creds.delete(CB::HOST)
+      Token.delete(CB::HOST)
+    end
+  end
+end

--- a/src/cb/token.cr
+++ b/src/cb/token.cr
@@ -41,6 +41,10 @@ struct CB::Token
     fetch? host
   end
 
+  def self.delete(host)
+    File.delete(file_path(host)) if File.exists?(file_path(host))
+  end
+
   def expires_at : Time
     Time.unix expires
   end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -55,6 +55,11 @@ op = OptionParser.new do |parser|
     action = CB::Login.new
   end
 
+  parser.on("logout", "Remove stored API key and tokens") do
+    parser.banner = "cb logout"
+    action = CB::Logout.new
+  end
+
   parser.on("list", "List clusters") do
     parser.banner = "cb list"
     set_action List


### PR DESCRIPTION
These changes add a new command and action called `logout`. The purpose
of these are to allow a user to clear all credentials from their system
which has the effect of logging them out of the system.  To do this, we
remove both the stored credentials/API key. As well, we remove the
cached token regardless of whether or not it is expired.

In the case that none of the above items exist on the system, the effect
is the same as a no-op.

Mentioned in #47.