### PR TITLE
Add `--role` option to `psql` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `cb psql` to take `--role` to specify the name of the role to connect.
 - `cb logout` to logout a user from the CLI.
 
 

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -359,6 +359,21 @@ describe CB::Completion do
     result.should have_option "--cluster"
   end
 
+  it "completes psql" do
+    result = parse("cb psql ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb psql abc ")
+    result.should have_option "--database"
+    result.should have_option "--role"
+
+    result = parse("cb psql abc --database ")
+    result.empty?.should be_true
+
+    result = parse("cb psql abc --role ")
+    result.should eq CB::VALID_CLUSTER_ROLES.to_a
+  end
+
   it "completes scope" do
     result = parse("cb scope ")
     result.should have_option "--cluster"

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -405,11 +405,16 @@ class CB::Completion
     return cluster_suggestions if @args.size == 2
 
     if last_arg?("--database")
-      [] of String
+      return [] of String
+    end
+
+    if last_arg?("--role")
+      return VALID_CLUSTER_ROLES.to_a
     end
 
     suggest = [] of String
     suggest << "--database\tName of database" unless has_full_flag? :database
+    suggest << "--role\trole name" unless has_full_flag? :role
     suggest
   end
 

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -3,10 +3,16 @@ require "./action"
 class CB::Psql < CB::APIAction
   eid_setter cluster_id
   property database : String?
+  property role_name : String = "default"
 
   def run
     c = client.get_cluster cluster_id
-    uri = client.get_role(cluster_id, "default").uri
+
+    if @role_name == "user"
+      @role_name = "u_#{client.get_account.id}"
+    end
+
+    uri = client.get_role(cluster_id, @role_name).uri
     raise Error.new "null uri" if uri.nil?
 
     database.tap { |db| uri.path = db if db }

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -95,6 +95,7 @@ op = OptionParser.new do |parser|
     psql = set_action Psql
 
     parser.on("--database NAME", "Database name (default: postgres)") { |arg| psql.database = arg }
+    parser.on("--role NAME", "Role name (default: default)") { |arg| psql.role_name = arg }
     positional_args psql.cluster_id
   end
 


### PR DESCRIPTION
The `cb psql` command would only allow connecting via the `default`
role. So, here we're adding the ability to specify the role to connect
to the cluster as.  The valid options are the same as those for `cb
uri`, specifically `application`, `default`, `postgres` and `user`.

```
# completion of valid roles.
> ./bin/cb psql <cluster_id> --role
application  default  postgres  user

# connecting as `application` role.
> cb psql <cluster_id> --role application
connecting to personal/Cluster 2022-05-05 00_26_59
psql (14.4 (Ubuntu 14.4-1.pgdg18.04+1), server 14.2)
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
Type "help" for help.

personal/Cluster 2022-05-05 00_26_59/postgres=> select current_user;
 current_user
--------------
 application
(1 row)
```