### PR TITLE
Add `cb role list` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `cb role list` shows current roles for a cluster.
 - `cb psql` to take `--role` to specify the name of the role to connect.
 - `cb logout` to logout a user from the CLI.
 

--- a/shard.lock
+++ b/shard.lock
@@ -32,3 +32,7 @@ shards:
     git: https://github.com/spider-gazelle/ssh2.cr.git
     version: 1.5.3
 
+  tallboy:
+    git: https://github.com/epoch/tallboy.git
+    version: 0.9.3
+

--- a/shard.yml
+++ b/shard.yml
@@ -10,6 +10,8 @@ dependencies:
     github: spider-gazelle/ssh2.cr
   promise:
     github: spider-gazelle/promise
+  tallboy:
+    github: epoch/tallboy
 
 development_dependencies:
   ameba:

--- a/spec/cb/cluster_uri_spec.cr
+++ b/spec/cb/cluster_uri_spec.cr
@@ -4,9 +4,12 @@ private class ClusterURITestClient < CB::Client
   ACCOUNT = Account.new(
     id: "123",
     name: "user",
+    email: "test@example.com"
   )
 
   ROLE = Role.new(
+    account_id: ACCOUNT.id,
+    account_email: ACCOUNT.email,
     name: "u_" + ACCOUNT.id,
     password: "secret",
     uri: URI.parse "postgres://u_123:secret@localhost:5432/postgres",

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -465,6 +465,7 @@ describe CB::Completion do
     # cb role
     result = parse("cb role ")
     result.should have_option "create"
+    result.should have_option "list"
     result.should have_option "update"
     result.should have_option "destroy"
 
@@ -474,6 +475,19 @@ describe CB::Completion do
 
     result = parse("cb role create --cluster ")
     result.should eq ["abc\tmy team/my cluster"]
+
+    # cb role list
+    result = parse("cb role list ")
+    result.should have_option "--cluster"
+
+    result = parse("cb role list --cluster ")
+    result.should eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb role list --cluster abc ")
+    result.should have_option "--format"
+
+    result = parse("cb role list --cluster abc --format ")
+    result.should eq ["default", "json"]
 
     # cb role update
     result = parse("cb role update ")

--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -4,28 +4,73 @@ private class RoleTestClient < CB::Client
   ACCOUNT = Account.new(
     id: "123",
     name: "user",
+    email: "test@example.com"
   )
 
-  ROLE = Role.new(
+  CLUSTER = ClusterDetail.new(
+    id: "pkdpq6yynjgjbps4otxd7il2u4",
+    team_id: "teamid",
+    name: "abc",
+    state: "na",
+    created_at: Time.utc(2016, 2, 15, 10, 20, 30),
+    is_ha: false,
+    major_version: 12,
+    plan_id: "memory-4",
+    cpu: 4,
+    memory: 111,
+    oldest_backup: nil,
+    provider_id: "aws",
+    region_id: "us-east-2",
+    network_id: "nfpvoqooxzdrriu6w3bhqo55c4",
+    storage: 1234
+  )
+
+  SYSTEM_ROLE = Role.new(
+    name: "application",
+    uri: URI.parse "postgres://application:secret@localhost:5432/postgres"
+  )
+
+  USER_ROLE = Role.new(
+    account_email: ACCOUNT.email,
+    account_id: ACCOUNT.id,
     name: "u_" + ACCOUNT.id,
     password: "secret",
     uri: URI.parse "postgres://u_123:secret@localhost:5432/postgres"
+  )
+
+  TEAM = Team.new(
+    id: "ijpjdc2a4vhphhels3krggqhyu",
+    name: "Test Team",
+    is_personal: false,
+    role: "admin",
   )
 
   def get_account
     ACCOUNT
   end
 
+  def get_cluster(id)
+    CLUSTER
+  end
+
+  def get_team(id)
+    TEAM
+  end
+
   def create_role(id : String)
-    ROLE
+    USER_ROLE
+  end
+
+  def list_roles(id : String)
+    [SYSTEM_ROLE, USER_ROLE]
   end
 
   def update_role(id : String, name : String, opts)
-    ROLE
+    USER_ROLE
   end
 
   def delete_role(id : String, name : String)
-    ROLE
+    USER_ROLE
   end
 end
 
@@ -49,6 +94,74 @@ describe CB::RoleCreate do
     action.call
 
     output.to_s.should eq "Role u_123 created on cluster #{action.cluster_id}.\n"
+  end
+end
+
+describe CB::RoleList do
+  it "validates that required arguments are present" do
+    action = CB::RoleCreate.new(RoleTestClient.new(TEST_TOKEN))
+
+    msg = /Missing required argument/
+
+    expect_cb_error(msg) { action.validate }
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.validate.should eq true
+  end
+
+  it "outputs default" do
+    client = RoleTestClient.new(TEST_TOKEN)
+
+    action = CB::RoleList.new(client)
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+
+    action.call
+
+    expected = <<-EXPECTED
+    +-------------------------------------+
+    | Cluster: abc                        |
+    | Team:    Test Team                  |
+    +------------------+------------------+
+    | Role             | Account          |
+    +------------------+------------------+
+    | application      | system           |
+    | u_123            | test@example.com |
+    +------------------+------------------+\n
+    EXPECTED
+
+    output.to_s.should eq expected
+  end
+
+  it "outputs json" do
+    client = RoleTestClient.new(TEST_TOKEN)
+
+    action = CB::RoleList.new(client)
+    action.format = CB::RoleList::Format::JSON
+    action.output = output = IO::Memory.new
+
+    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+
+    action.call
+
+    expected = <<-EXPECTED
+    {
+      "cluster": "abc",
+      "team": "Test Team",
+      "roles": [
+        {
+          "role": "application",
+          "account": "system"
+        },
+        {
+          "role": "u_123",
+          "account": "test@example.com"
+        }
+      ]
+    }\n
+    EXPECTED
+
+    output.to_s.should eq expected
   end
 end
 

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -97,7 +97,10 @@ class CB::Client
   # Account
   #
 
-  jrecord Account, id : String, name : String
+  jrecord Account,
+    id : String,
+    name : String,
+    email : String
 
   # https://crunchybridgeapi.docs.apiary.io/#reference/0/account/get-account
   def get_account
@@ -446,7 +449,12 @@ class CB::Client
   # Cluster Roles
   #
 
-  jrecord Role, name : String?, password : String?, uri : URI?
+  jrecord Role,
+    account_id : String? = nil,
+    account_email : String? = nil,
+    name : String = "",
+    password : String? = nil,
+    uri : URI? = nil
 
   # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridroles/create-role
   def create_role(cluster_id)
@@ -458,6 +466,12 @@ class CB::Client
   def get_role(cluster_id, role_name)
     resp = get "clusters/#{cluster_id}/roles/#{role_name}"
     Role.from_json resp.body
+  end
+
+  # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridroles/list-roles
+  def list_roles(cluster_id)
+    resp = get "clusters/#{cluster_id}/roles"
+    Array(Role).from_json resp.body, root: "roles"
   end
 
   # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrolesrolename/update-role

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -282,12 +282,15 @@ class CB::Completion
       role_create
     when "destroy"
       role_destroy
+    when "list"
+      role_list
     when "update"
       role_update
     else
       [
         "create\tcreate a role for a cluster",
         "destroy\tremove a role from a cluster",
+        "list\tlist roles for a cluster",
         "update\tupdate a role for a cluster",
       ]
     end
@@ -320,6 +323,24 @@ class CB::Completion
 
     suggest = [] of String
     suggest << "--name\trole name" unless has_full_flag? :name
+    suggest
+  end
+
+  def role_list
+    return ["--cluster\tcluster id"] if args.size == 3
+
+    cluster = find_arg_value "--cluster"
+
+    if last_arg?("--cluster")
+      return cluster.nil? ? cluster_suggestions : [] of String
+    end
+
+    if last_arg?("--format")
+      return ["default", "json"]
+    end
+
+    suggest = [] of String
+    suggest << "--format\toutput format" unless has_full_flag? :format
     suggest
   end
 

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -1,4 +1,5 @@
 require "./action"
+require "tallboy"
 
 module CB
   # Valid cluster role names.
@@ -23,6 +24,79 @@ class CB::RoleCreate < CB::RoleAction
 
     role = client.create_role @cluster_id
     output << "Role #{role.name} created on cluster #{@cluster_id}.\n"
+  end
+end
+
+class CB::RoleList < CB::RoleAction
+  enum Format
+    Default
+    JSON
+  end
+
+  property format : Format = Format::Default
+
+  private property cluster : Client::ClusterDetail?
+
+  private property roles : Array(Hash(String, String)) = [] of Hash(String, String)
+
+  private property team : Client::Team?
+
+  def validate
+    check_required_args do |missing|
+      missing << "cluster" unless cluster_id
+    end
+  end
+
+  def run
+    validate
+
+    @cluster = client.get_cluster @cluster_id
+    @team = client.get_team @cluster.try &.team_id
+
+    r = client.list_roles @cluster_id
+
+    r.each do |role|
+      @roles << {
+        "role"    => role.name,
+        "account" => role.name.starts_with?("u_") ? role.account_email.to_s : "system",
+      }
+    end
+
+    case @format
+    when Format::JSON
+      output_json
+    when Format::Default
+      output_default
+    end
+  end
+
+  def output_default
+    table = Tallboy.table do
+      columns do
+        add "Role"
+        add "Account"
+      end
+
+      header <<-GENERAL_HEADER
+        Cluster: #{@cluster.try &.name}
+        Team:    #{@team.try &.name}
+        GENERAL_HEADER
+
+      header
+
+      @roles.each do |role|
+        row [role["role"], role["account"]]
+      end
+    end
+    output << table.render(:ascii) << '\n'
+  end
+
+  def output_json
+    output << {
+      "cluster": @cluster.try &.name,
+      "team":    @team.try &.name,
+      "roles":   @roles,
+    }.to_pretty_json << '\n'
   end
 end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -250,6 +250,20 @@ op = OptionParser.new do |parser|
       parser.on("--cluster ID", "Choose cluster") { |arg| create.cluster_id = arg }
     end
 
+    parser.on("destroy", "Destroy a cluster role") do
+      destroy = set_action RoleDelete
+      parser.banner = "cb role destroy <--cluster> <--name>"
+      parser.on("--cluster ID", "Choose cluster") { |arg| destroy.cluster_id = arg }
+      parser.on("--name NAME", "Role name") { |arg| destroy.role_name = arg }
+    end
+
+    parser.on("list", "List cluster roles") do
+      list = set_action RoleList
+      parser.banner = "cb role list <--cluster>"
+      parser.on("--cluster ID", "Choose cluster") { |arg| list.cluster_id = arg }
+      parser.on("--format FORMAT", "Choose output format") { |arg| list.format = CB::RoleList::Format.parse(arg) }
+    end
+
     parser.on("update", "Update a cluster role") do
       update = set_action RoleUpdate
       parser.banner = "cb role update <--cluster> <--name> [--mode] [--rotate-password]"
@@ -257,13 +271,6 @@ op = OptionParser.new do |parser|
       parser.on("--name NAME", "Role name") { |arg| update.role_name = arg }
       parser.on("--read-only <true|false>", "Read-only") { |arg| update.read_only = arg }
       parser.on("--rotate-password <true|false>", "Rotate password") { |arg| update.rotate_password = arg }
-    end
-
-    parser.on("destroy", "Destroy a cluster role") do
-      destroy = set_action RoleDelete
-      parser.banner = "cb role destroy <--cluster> <--name>"
-      parser.on("--cluster ID", "Choose cluster") { |arg| destroy.cluster_id = arg }
-      parser.on("--name NAME", "Role name") { |arg| destroy.role_name = arg }
     end
   end
 


### PR DESCRIPTION
Add command to list a clusters roles.

`cb role list --cluster <cluster id>`

We also introduce a new dependency, of `epoch/tallboy` for more easily formatting output in table format. I had reviewed a few different libraries for this kind of thing and this one seemed to be the easiest to use as well as providing some more advanced features to include extending it for our purposes if necessary.  Initially I went with the `:ascii` renderer, but there I nothing preventing us from going a different direction with it if desired.

For roles `postgres` and `application` the associated account is set to `(system)`.  In the case of it being a user role, in other words starting with `u_` we display the associated account email.

Example:

```
> ./bin/cb role list --cluster ijpjdc2a4vhphhels3krggqhyu
+----------------------------------------------------------------+
| Cluster: Cluster 2022-05-05 00_26_59                           |
| Team:    personal                                              |
+------------------------------+---------------------------------+
| Role                         | Account                         |
+------------------------------+---------------------------------+
| application                  | (system)                        |
| postgres                     | (system)                        |
| u_sipm5b7unvehtadzukymk25ni4 | adam.brightwell@is-awesome.com  |
+------------------------------+---------------------------------+
```
```
> ./bin/cb role list --cluster ijpjdc2a4vhphhels3krggqhyu --format json
{
  "cluster": "Cluster 2022-05-05 00_26_59",
  "team": "personal",
  "roles": [
    {
      "role": "application",
      "account": "system"
    },
    {
      "role": "postgres",
      "account": "system"
    },
    {
      "role": "u_sipm5b7unvehtadzukymk25ni4",
      "account": "adam.brightwell@is-awesome.com"
    }
  ]
}


```

Note: This is a command that only works for users that are an admin of a team.

