### PR TITLE
Fix no output from `cb token`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- No output from `cb token`.
 
 ## [2.2.0] - 2022-08-19
 ### Added

--- a/src/cb/token.cr
+++ b/src/cb/token.cr
@@ -18,9 +18,9 @@ class CB::TokenAction < CB::Action
 
   def run
     case @format
-    when "header"
+    when Format::Header
       output << "Authorization: Bearer #{token.token}"
-    when "default"
+    when Format::Default
       output << token.token
     end
   end


### PR DESCRIPTION
Here we fix a bug with `cb token` that was preventing it from providing
any output.

The issue was that we were switching on a string for the format instead
of the enum for the format. This was due to a recent change on how the
format is set via `cli.cr`.