### PR TITLE
Add `host` to `cb info`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `host` field to `cb info` output. 
 
 ## [2.2.1] - 2022-08-22
 ### Fixed

--- a/spec/cb/cluster_create_spec.cr
+++ b/spec/cb/cluster_create_spec.cr
@@ -12,6 +12,7 @@ private class ClusterCreateTestClient < CB::Client
       name: "source cluster",
       state: "na",
       created_at: Time.utc(2016, 2, 15, 10, 20, 30),
+      host: "p.#{id}.test.crunchybridge.com",
       is_ha: false,
       major_version: 12,
       plan_id: "memory-4",

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -37,6 +37,7 @@ private class ClusterUpgradeTestClient < CB::Client
       name: "source cluster",
       state: "na",
       created_at: Time.utc(2016, 2, 15, 10, 20, 30),
+      host: "p.#{id}.test.crunchybridge.com",
       is_ha: false,
       major_version: 12,
       plan_id: "memory-4",

--- a/spec/cb/restart_spec.cr
+++ b/spec/cb/restart_spec.cr
@@ -8,6 +8,7 @@ private class RestartTestClient < CB::Client
       name: "source cluster",
       state: "na",
       created_at: Time.utc(2016, 2, 15, 10, 20, 30),
+      host: "p.#{id}.test.crunchybridge.com",
       is_ha: false,
       major_version: 12,
       plan_id: "memory-4",

--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -13,6 +13,7 @@ private class RoleTestClient < CB::Client
     name: "abc",
     state: "na",
     created_at: Time.utc(2016, 2, 15, 10, 20, 30),
+    host: "p.pkdpq6yynjgjbps4otxd7il2u4.test.crunchybridge.com",
     is_ha: false,
     major_version: 12,
     plan_id: "memory-4",

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -258,6 +258,7 @@ class CB::Client
     state : String?,
     created_at : Time,
     cpu : Int32,
+    host : String,
     is_ha : Bool,
     plan_id : String,
     major_version : Int32,

--- a/src/cb/cluster_info.cr
+++ b/src/cb/cluster_info.cr
@@ -9,6 +9,7 @@ class CB::ClusterInfo < CB::APIAction
 
     details = {
       "state"    => c.state,
+      "host"     => c.host,
       "created"  => c.created_at.to_rfc3339,
       "plan"     => "#{c.plan_id} (#{c.memory}GiB ram, #{c.cpu}vCPU)",
       "version"  => c.major_version,


### PR DESCRIPTION
Bridge API has recently started including the cluster host information
as part of the cluster details responses.  Here we're just exposing that
via the `cb info` command.

Example:

```
> ./bin/cb info uefntqqx5raldche26vz2pgtza
personal/example-cluster
     state: ready
      host: p.uefntqqx5raldche26vz2pgtza.test.crunchybridge.com
   created: 2021-12-14T23:24:08Z
      plan: hobby-4 (4GiB ram, 1vCPU)
   version: 13
   storage: 10GiB
        ha: on
  platform: aws
    region: us-east-1
   network: ftizro6zx5frzcjiksxosph3ku
  firewall: allowed cidrs
              192.168.0.0/22
```