### PR TITLE
Improve role name validation error message.

### DIFF
--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -173,7 +173,7 @@ Spectator.describe RoleUpdate do
   it "#run errors on invalid role" do
     action.role_name = "invalid"
 
-    expect(&.call).to raise_error Program::Error, /invalid role '#{action.role_name}'/
+    expect(&.call).to raise_error Program::Error, /invalid role: '#{action.role_name}'/
   end
 
   it "#run translates 'user' role" do
@@ -215,7 +215,7 @@ Spectator.describe RoleDelete do
   it "#run errors on invalid role" do
     action.role_name = "invalid"
 
-    expect(&.call).to raise_error Program::Error, /invalid role '#{action.role_name}'/
+    expect(&.call).to raise_error Program::Error, /invalid role: '#{action.role_name}'/
   end
 
   it "#run translates 'user' role" do

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -9,6 +9,12 @@ end
 abstract class CB::RoleAction < CB::APIAction
   eid_setter cluster_id
   property role_name : String?
+
+  def validate_role_name(role)
+    unless VALID_CLUSTER_ROLES.includes? @role_name
+      raise Error.new("invalid role: '#{@role_name}'. Must be one of: #{VALID_CLUSTER_ROLES.join ", "}")
+    end
+  end
 end
 
 # Action to create a cluster role for the calling user.
@@ -117,7 +123,9 @@ class CB::RoleUpdate < CB::RoleAction
 
     # Ensure the role name
     @role_name = "default" unless @role_name
-    raise Error.new("invalid role '#{@role_name}'") unless VALID_CLUSTER_ROLES.includes? @role_name
+
+    validate_role_name @role_name
+
     if @role_name == "user"
       @role_name = "u_" + client.get_account.id
     end
@@ -139,7 +147,9 @@ class CB::RoleDelete < CB::RoleAction
 
     # Ensure the role name
     @role_name = "default" unless @role_name
-    raise Error.new("invalid role '#{@role_name}'") unless VALID_CLUSTER_ROLES.includes? @role_name
+
+    validate_role_name @role_name
+
     if @role_name == "user"
       @role_name = "u_" + client.get_account.id
     end


### PR DESCRIPTION
Previously, when an invalid role name was provided to `role update` or `role destroy` our error message was simply `invalid role` with nothing else very helpful provided. Here we're improving that message by also providing the list of currently supported valid role name values.

Example:

```
> ./bin/cb role destroy --cluster 66zlqgtfhrg4vlrhzt6ptbys2y --name test
error: invalid role: 'test'. Must be one of: application, default, postgres, user
```