### PR TITLE
Add API_NAME_PATTERN.

### DIFF
--- a/spec/cb_spec.cr
+++ b/spec/cb_spec.cr
@@ -1,4 +1,17 @@
 require "./spec_helper"
+include CB
 
 Spectator.describe CB do
+  describe "IDENT_PATTERN" do
+    subject { IDENT_PATTERN.matches? str }
+    provided str: "abc" { expect { subject }.to be_true }
+    provided str: "a_b_c" { expect { subject }.to be_false }
+  end
+
+  describe "API_NAME_PATTERN" do
+    subject { API_NAME_PATTERN.matches? str }
+    provided str: "abc" { expect { subject }.to be_false }
+    provided str: "abcde" { expect { subject }.to be_true }
+    provided str: "abc 2022/05/09" { expect { subject }.to be_true }
+  end
 end

--- a/src/cb.cr
+++ b/src/cb.cr
@@ -1,7 +1,16 @@
 module CB
   # Global application constants.
+
   EID_PATTERN = /\A[a-z0-9]{25}[4aeimquy]\z/
-  HOST        = ENV["CB_HOST"]? || "api.crunchybridge.com"
+
+  # For simple identifiers such as region names, or plan names where we
+  # expect only lowercase, numbers, and -
+  IDENT_PATTERN = /\A[a-z0-9\-]+\z/
+
+  # For user specified API resource names such as cluster and team names.
+  API_NAME_PATTERN = /\A[\p{L}\p{So}][\p{L}\p{N}\p{So}\/\-_ ']{3,48}[\p{L}\p{N}\p{So}]\z/
+
+  HOST = ENV["CB_HOST"]? || "api.crunchybridge.com"
 
   # Release constants.
   BUILD_RELEASE  = {{ flag?(:release) }}

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -33,7 +33,27 @@ module CB
       property {{property}} : String?
 
       def {{property}}=(str : String)
-        raise_arg_error {{property.stringify}}, str unless str =~ /\A[a-z0-9\-]+\z/
+        raise_arg_error {{property.stringify}}, str unless str =~ IDENT_PATTERN
+        @{{property}} = str
+      end
+    end
+
+    # Non-nilable name setter. Used for name associated with API resources.
+    macro name_setter(property)
+      property {{property}} : String = ""
+
+      def {{property}}=(str : String)
+        raise_arg_error {{property.stringify}}, str unless str =~ API_NAME_PATTERN
+        @{{property}} = str
+      end
+    end
+
+    # Nilable name setter. Used for name associated with API resources.
+    macro name_setter?(property)
+      property {{property}} : String?
+
+      def {{property}}=(str : String)
+        raise_arg_error {{property.stringify}}, str unless str =~ API_NAME_PATTERN
         @{{property}} = str
       end
     end

--- a/src/cb/cluster_create.cr
+++ b/src/cb/cluster_create.cr
@@ -2,7 +2,7 @@ require "./action"
 
 class CB::ClusterCreate < CB::APIAction
   bool_setter ha
-  property name : String?
+  name_setter? name
   ident_setter plan
   property platform : String?
   i32_setter postgres_version

--- a/src/cb/team.cr
+++ b/src/cb/team.cr
@@ -15,7 +15,7 @@ abstract class CB::TeamAction < CB::APIAction
 end
 
 class CB::TeamCreate < CB::TeamAction
-  property name : String = ""
+  name_setter name
 
   def run
     check_required_args do |missing|


### PR DESCRIPTION
The API has some restrictions on what is allowed for user provided names of resources, for instance team or cluster names.  So, here we are adding a pattern for validating such names.