### PR TITLE
Add `Identifier` class.

### DIFF
--- a/spec/cb/identifier_spec.cr
+++ b/spec/cb/identifier_spec.cr
@@ -1,0 +1,26 @@
+require "../spec_helper"
+
+Spectator.describe CB::Identifier do
+  describe "#initialize" do
+    subject { described_class.new(id) }
+    provided id: "pkdpq6yynjgjbps4otxd7il2u4" do
+      expect(&.to_s).to eq id
+      expect(&.eid?).to be_true
+      expect(&.api_name?).to be_true
+    end
+
+    provided id: "test-cluster" do
+      expect(&.to_s).to eq id
+      expect(&.eid?).to be_false
+      expect(&.api_name?).to be_true
+    end
+
+    provided id: "abc" do
+      expect { described_class.new(id) }.to raise_error CB::Program::Error, /invalid identifier/
+    end
+
+    provided id: "" do
+      expect { described_class.new(id) }.to raise_error CB::Program::Error, /invalid identifier/
+    end
+  end
+end

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -27,6 +27,19 @@ module CB
       end
     end
 
+    macro cluster_identifier_setter(property)
+      property {{property}} : Hash(Symbol, Identifier) = Hash(Symbol, Identifier).new
+
+      def {{property}}=(str : String)
+        raise Program::Error.new "invalid cluster identifier" if str.empty?
+
+        parts = str.split '/'
+
+        @{{property}}[:team] =  Identifier.new(parts.shift) unless parts.size == 1
+        @{{property}}[:cluster] = Identifier.new(parts.shift)
+      end
+    end
+
     # For simple identifiers such as region names, or plan names where we
     # expect only lowercase, numbers, and -
     macro ident_setter(property)

--- a/src/cb/identifier.cr
+++ b/src/cb/identifier.cr
@@ -1,0 +1,19 @@
+module CB
+  class Identifier
+    def initialize(@value : String = "")
+      raise Program::Error.new "invalid identifier: '#{@value}'" unless eid? || api_name?
+    end
+
+    def eid?
+      EID_PATTERN.matches? @value
+    end
+
+    def api_name?
+      API_NAME_PATTERN.matches? @value
+    end
+
+    def to_s(io : IO)
+      io << @value
+    end
+  end
+end


### PR DESCRIPTION
Adds a class for encapsulating identifiers for resources like a team or a cluster.

This identifier can be the form of an eid or an api name. Validation is peformed using the respective regex patterns.

This will come in handy with some upcoming improvements I'm working on to allow for providing cluster names and teams as identifiers to commands.