### PR TITLE
Allow `cb info` to receive team and cluster names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `host` field to `cb info` output. 
+- Support for using cluster name or id with `cb info`.
+- `host` field to `cb info` output.
 
 ## [2.2.1] - 2022-08-22
 ### Fixed

--- a/spec/cb/cluster_info_spec.cr
+++ b/spec/cb/cluster_info_spec.cr
@@ -1,0 +1,55 @@
+require "../spec_helper"
+include CB
+
+Spectator.describe CB::ClusterInfo do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  let(client) { Client.new TEST_TOKEN }
+  let(cluster) { Factory.cluster }
+  let(team) { Factory.team }
+
+  mock Client do
+    stub get_cluster(id : Identifier)
+    stub get_team(id)
+    stub get_firewall_rules(id)
+  end
+
+  describe "#validate" do
+    it "ensures required arguments are present" do
+      expect(&.validate).to raise_error Program::Error, /Missing required argument/
+
+      action.cluster_id = cluster.id
+      expect(&.validate).to be_true
+    end
+  end
+
+  describe "#call" do
+    it "outputs default format" do
+      action.output = IO::Memory.new
+      action.cluster_id = team.id + "/" + cluster.id
+
+      expect(client).to receive(:get_cluster).with(action.cluster_id[:cluster]).and_return cluster
+      expect(client).to receive(:get_team).with(cluster.team_id).and_return team
+      expect(client).to receive(:get_firewall_rules).with(cluster.id).and_return [] of Client::FirewallRule
+
+      action.call
+
+      expected = <<-EXPECTED
+      Test Team/abc
+           state: na
+            host: p.pkdpq6yynjgjbps4otxd7il2u4.example.com
+         created: 2016-02-15T10:20:30Z
+            plan: memory-4 (111GiB ram, 4vCPU)
+         version: 12
+         storage: 1234GiB
+              ha: off
+        platform: aws
+          region: us-east-2
+         network: nfpvoqooxzdrriu6w3bhqo55c4
+        firewall: no rules\n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+  end
+end

--- a/spec/cb/identifier_spec.cr
+++ b/spec/cb/identifier_spec.cr
@@ -6,7 +6,7 @@ Spectator.describe CB::Identifier do
     provided id: "pkdpq6yynjgjbps4otxd7il2u4" do
       expect(&.to_s).to eq id
       expect(&.eid?).to be_true
-      expect(&.api_name?).to be_true
+      expect(&.api_name?).to be_false
     end
 
     provided id: "test-cluster" do

--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -51,7 +51,7 @@ Spectator.describe RoleList do
 
   mock Client do
     stub list_roles(id)
-    stub get_cluster(id)
+    stub get_cluster(id : String?)
     stub get_team(id)
   end
 

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -272,7 +272,17 @@ class CB::Client
     getter source_cluster_id : String?
   end
 
-  def get_cluster(id)
+  # Retrieve the cluster by id or by name.
+  def get_cluster(id : Identifier)
+    return get_cluster id.to_s if id.eid?
+    cluster = get_clusters.find { |c| id == c.name }
+    raise Program::Error.new "cluster #{id.to_s.colorize.t_name} does not exist." unless cluster
+    get_cluster cluster.id
+  end
+
+  # TODO (abrightwell): track down why this must be nilable. Seems reasonable
+  # that it shouldn't require it to be.
+  def get_cluster(id : String?)
     resp = get "clusters/#{id}"
     ClusterDetail.from_json resp.body
   rescue e : Error

--- a/src/cb/cluster_info.cr
+++ b/src/cb/cluster_info.cr
@@ -1,10 +1,19 @@
 require "./action"
 
 class CB::ClusterInfo < CB::APIAction
-  eid_setter cluster_id
+  cluster_identifier_setter cluster_id
+
+  def validate
+    check_required_args do |missing|
+      missing << "cluster" if @cluster_id.empty?
+    end
+  end
 
   def run
-    c = client.get_cluster cluster_id
+    validate
+
+    c = client.get_cluster(cluster_id[:cluster])
+
     print_team_slash_cluster c
 
     details = {
@@ -31,7 +40,7 @@ class CB::ClusterInfo < CB::APIAction
       output << v << "\n"
     end
 
-    firewall_rules = client.get_firewall_rules cluster_id
+    firewall_rules = client.get_firewall_rules c.id
     output << "firewall".rjust(pad).colorize.bold << ": "
     if firewall_rules.empty?
       output << "no rules\n"

--- a/src/cb/identifier.cr
+++ b/src/cb/identifier.cr
@@ -4,11 +4,16 @@ module CB
       raise Program::Error.new "invalid identifier: '#{@value}'" unless eid? || api_name?
     end
 
+    def ==(str : String)
+      @value == str
+    end
+
     def eid?
       EID_PATTERN.matches? @value
     end
 
     def api_name?
+      return false if EID_PATTERN.matches? @value
       API_NAME_PATTERN.matches? @value
     end
 


### PR DESCRIPTION
Here we're adding the ability to provide a `name` for both a team and a cluster for the `cb info` command.

The command continues to support providing an id for both as well.

The following formats for specifying the cluster are as follows:

* `<cluster id>`
* `<cluster name>`
* `<team id | name>/<cluster id | name>`

Example:

```
> ./bin/cb info jf5iwpqqz5d25hfm6rcdtlwwuq
personal/Cluster 2022-05-05 00_26_59
     state: ready
      host: p.jf5iwpqqz5d25hfm6rcdtlwwuq.db.postgresbridge.com
   created: 2022-05-05T00:27:00Z
      plan: hobby-2 (2GiB ram, 1vCPU)
   version: 14
   storage: 100GiB
        ha: off
  platform: aws
    region: us-east-1
   network: 4cqx2fw46vgfpk25u2rr2eessa
  firewall: allowed cidrs
              0.0.0.0/0
              ::/0
```

```
> ./bin/cb info "Cluster 2022-05-05 00_26_59"
personal/Cluster 2022-05-05 00_26_59
     state: ready
      host: p.jf5iwpqqz5d25hfm6rcdtlwwuq.db.postgresbridge.com
   created: 2022-05-05T00:27:00Z
      plan: hobby-2 (2GiB ram, 1vCPU)
   version: 14
   storage: 100GiB
        ha: off
  platform: aws
    region: us-east-1
   network: 4cqx2fw46vgfpk25u2rr2eessa
  firewall: allowed cidrs
              0.0.0.0/0
              ::/0

```

```
> ./bin/cb info "personal/bfyjwggzezafvo5buespe4axna"
personal/Cluster 2022-05-05 00_26_59
     state: ready
      host: p.jf5iwpqqz5d25hfm6rcdtlwwuq.db.postgresbridge.com
   created: 2022-05-05T00:27:00Z
      plan: hobby-2 (2GiB ram, 1vCPU)
   version: 14
   storage: 100GiB
        ha: off
  platform: aws
    region: us-east-1
   network: 4cqx2fw46vgfpk25u2rr2eessa
  firewall: allowed cidrs
              0.0.0.0/0
              ::/0
```

```
> ./bin/cb info "personal/Cluster 2022-05-05 00_26_59"
personal/Cluster 2022-05-05 00_26_59
     state: ready
      host: p.jf5iwpqqz5d25hfm6rcdtlwwuq.db.postgresbridge.com
   created: 2022-05-05T00:27:00Z
      plan: hobby-2 (2GiB ram, 1vCPU)
   version: 14
   storage: 100GiB
        ha: off
  platform: aws
    region: us-east-1
   network: 4cqx2fw46vgfpk25u2rr2eessa
  firewall: allowed cidrs
              0.0.0.0/0
              ::/0
```