### PR TITLE
Allow `cb uri` to receive team and cluster names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Support for using cluster name or id with `cb info`.
+- Support for using cluster name or id with `cb info` and `cb uri`.
 - `host` field to `cb info` output.
 
 ## [2.2.1] - 2022-08-22

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -38,7 +38,7 @@ module Factory
       account_email: "user@example.com",
       name:          "u_mijrfkkuqvhernzfqcbqf7b6me",
       password:      "secret",
-      uri:           URI.parse "postgres://u_mijrfkkuqvhernzfqcbqf7b6me:secret@example.com",
+      uri:           URI.parse "postgres://u_mijrfkkuqvhernzfqcbqf7b6me:secret@example.com:5432/postgres",
     }.merge(params)
 
     CB::Client::Role.new **params
@@ -48,7 +48,7 @@ module Factory
     params = {
       name:     "application",
       password: "secret",
-      uri:      URI.parse "postgres://application:secret@example.com",
+      uri:      URI.parse "postgres://application:secret@example.com:5432/postgres",
     }.merge(params)
 
     CB::Client::Role.new **params

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -41,6 +41,14 @@ module CB
     end
 
     macro role_setter(property)
+      property {{property}} : Role = Role.new
+
+      def {{property}}=(str : String)
+        @{{property}} = Role.new str
+      end
+    end
+
+    macro role_setter?(property)
       property {{property}} : Role?
 
       def {{property}}=(str : String)

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -275,6 +275,10 @@ class CB::Client
   # Retrieve the cluster by id or by name.
   def get_cluster(id : Identifier)
     return get_cluster id.to_s if id.eid?
+    get_cluster_by_name(id)
+  end
+
+  private def get_cluster_by_name(id : Identifier)
     cluster = get_clusters.find { |c| id == c.name }
     raise Program::Error.new "cluster #{id.to_s.colorize.t_name} does not exist." unless cluster
     get_cluster cluster.id
@@ -474,6 +478,12 @@ class CB::Client
   end
 
   # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrolesrolename/get-role
+  def get_role(cluster_id : Identifier, role_name : String)
+    return get_role(cluster_id.to_s, role_name) if cluster_id.eid?
+    c = get_cluster_by_name(cluster_id)
+    get_role(c.id, role_name)
+  end
+
   def get_role(cluster_id, role_name)
     resp = get "clusters/#{cluster_id}/roles/#{role_name}"
     Role.from_json resp.body

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -3,7 +3,6 @@ require "tallboy"
 
 abstract class CB::RoleAction < CB::APIAction
   eid_setter cluster_id
-  role_setter role
 end
 
 # Action to create a cluster role for the calling user.
@@ -97,6 +96,7 @@ end
 
 # Action to update a cluster role.
 class CB::RoleUpdate < CB::RoleAction
+  role_setter? role
   bool_setter? read_only
   bool_setter? rotate_password
 
@@ -123,6 +123,8 @@ class CB::RoleUpdate < CB::RoleAction
 end
 
 class CB::RoleDelete < CB::RoleAction
+  role_setter? role
+
   def validate
     check_required_args do |missing|
       missing << "cluster" unless cluster_id

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -86,7 +86,7 @@ op = OptionParser.new do |parser|
     parser.banner = "cb uri <cluster id> [--role]"
     uri = set_action ClusterURI
 
-    parser.on("--role NAME", "Role name (default: default)") { |arg| uri.role_name = arg }
+    parser.on("--role NAME", "Role name (default: default)") { |arg| uri.role = CB::Role.new arg }
     positional_args uri.cluster_id
   end
 


### PR DESCRIPTION
Here we're adding the ability to provide a `name` for both a team and a cluster for the `cb uri` command.

The command continues to support providing an id for both as well.