### PR TITLE
Add `CB::Role` type.

### DIFF
--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -379,7 +379,7 @@ Spectator.describe CB::Completion do
     result.empty?.should be_true
 
     result = parse("cb psql abc --role ")
-    result.should eq CB::VALID_CLUSTER_ROLES.to_a
+    result.should eq CB::Role::VALID_CLUSTER_ROLES.to_a
   end
 
   it "completes scope" do
@@ -526,7 +526,7 @@ Spectator.describe CB::Completion do
 
     result = parse("cb role destroy --name ")
     expect(result).to_not have_option "--name"
-    expect(result).to eq CB::VALID_CLUSTER_ROLES.to_a
+    expect(result).to eq CB::Role::VALID_CLUSTER_ROLES.to_a
   end
 
   it "completes uri" do
@@ -537,7 +537,7 @@ Spectator.describe CB::Completion do
     expect(result).to have_option "--role"
 
     result = parse("cb uri abc --role ")
-    expect(result).to eq CB::VALID_CLUSTER_ROLES.to_a
+    expect(result).to eq CB::Role::VALID_CLUSTER_ROLES.to_a
   end
 
   it "completes team" do

--- a/spec/cb/types_spec.cr
+++ b/spec/cb/types_spec.cr
@@ -1,0 +1,26 @@
+require "../spec_helper"
+include CB
+
+Spectator.describe CB::Role do
+  describe "#initialize" do
+    subject { described_class }
+    it "creates default" do
+      expect(&.new.name).to eq "default"
+    end
+
+    sample CB::Role::VALID_CLUSTER_ROLES do |name|
+      it "creates with valid name" do
+        expect(&.new(name)).to_not be_nil
+      end
+    end
+
+    it "allows u_<id> name" do
+      expect(&.new("u_t7c5psndzrfzrgjvkiuty5cd4e")).to_not be_nil
+    end
+
+    it "errors with invalid name" do
+      expect(&.new("invalid")).to raise_error Program::Error, /invalid role: 'invalid'/
+      expect(&.new("u_abc")).to raise_error Program::Error, /invalid role: 'u_abc'/
+    end
+  end
+end

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -1,6 +1,15 @@
 module Factory
   extend self
 
+  def account(**params)
+    params = {
+      id:    "mijrfkkuqvhernzfqcbqf7b6me",
+      name:  "user",
+      email: "user@example.com",
+    }.merge(params)
+    CB::Client::Account.new **params
+  end
+
   def cluster(**params)
     params = {
       id:            "pkdpq6yynjgjbps4otxd7il2u4",
@@ -22,6 +31,27 @@ module Factory
     }.merge(params)
 
     CB::Client::ClusterDetail.new **params
+  end
+
+  def user_role(**params)
+    params = {
+      account_email: "user@example.com",
+      name:          "u_mijrfkkuqvhernzfqcbqf7b6me",
+      password:      "secret",
+      uri:           URI.parse "postgres://u_mijrfkkuqvhernzfqcbqf7b6me:secret@example.com",
+    }.merge(params)
+
+    CB::Client::Role.new **params
+  end
+
+  def system_role(**params)
+    params = {
+      name:     "application",
+      password: "secret",
+      uri:      URI.parse "postgres://application:secret@example.com",
+    }.merge(params)
+
+    CB::Client::Role.new **params
   end
 
   def team(**params)

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -40,6 +40,14 @@ module CB
       end
     end
 
+    macro role_setter(property)
+      property {{property}} : Role?
+
+      def {{property}}=(str : String)
+        @{{property}} = Role.new str
+      end
+    end
+
     # For simple identifiers such as region names, or plan names where we
     # expect only lowercase, numbers, and -
     macro ident_setter(property)

--- a/src/cb/cluster_uri.cr
+++ b/src/cb/cluster_uri.cr
@@ -6,7 +6,7 @@ class CB::ClusterURI < CB::APIAction
 
   def run
     # Ensure the role name
-    raise Error.new("invalid role: '#{@role_name}'") unless VALID_CLUSTER_ROLES.includes? @role_name
+    raise Error.new("invalid role: '#{@role_name}'") unless Role::VALID_CLUSTER_ROLES.includes? @role_name
     if @role_name == "user"
       @role_name = "u_#{client.get_account.id}"
     end

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -318,7 +318,7 @@ class CB::Completion
     end
 
     if last_arg? "--name"
-      return VALID_CLUSTER_ROLES.to_a
+      return Role::VALID_CLUSTER_ROLES.to_a
     end
 
     suggest = [] of String
@@ -354,7 +354,7 @@ class CB::Completion
     end
 
     if last_arg? "--name"
-      return VALID_CLUSTER_ROLES.to_a
+      return Role::VALID_CLUSTER_ROLES.to_a
     end
 
     if last_arg?("--read-only")
@@ -430,7 +430,7 @@ class CB::Completion
     end
 
     if last_arg?("--role")
-      return VALID_CLUSTER_ROLES.to_a
+      return Role::VALID_CLUSTER_ROLES.to_a
     end
 
     suggest = [] of String
@@ -771,7 +771,7 @@ class CB::Completion
     return cluster_suggestions if @args.size == 2
 
     if last_arg? "--role"
-      return VALID_CLUSTER_ROLES.to_a
+      return Role::VALID_CLUSTER_ROLES.to_a
     end
 
     suggest = [] of String

--- a/src/cb/types.cr
+++ b/src/cb/types.cr
@@ -1,0 +1,26 @@
+module CB
+  struct Role
+    getter name : String
+
+    VALID_CLUSTER_ROLES = Set{"application", "default", "postgres", "user"}
+
+    private INVALID_ROLE_MESSAGE = "invalid role: '%s'. Must be one of: #{VALID_CLUSTER_ROLES.join ", "}"
+
+    def ==(name : String)
+      @name == name
+    end
+
+    def initialize(@name : String = "default")
+      raise Program::Error.new INVALID_ROLE_MESSAGE % @name unless is_valid?
+    end
+
+    def is_valid?
+      return true if EID_PATTERN.matches? @name.lchop("u_")
+      VALID_CLUSTER_ROLES.includes? @name
+    end
+
+    def to_s(io : IO)
+      io << @name
+    end
+  end
+end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -254,7 +254,7 @@ op = OptionParser.new do |parser|
       destroy = set_action RoleDelete
       parser.banner = "cb role destroy <--cluster> <--name>"
       parser.on("--cluster ID", "Choose cluster") { |arg| destroy.cluster_id = arg }
-      parser.on("--name NAME", "Role name") { |arg| destroy.role_name = arg }
+      parser.on("--name NAME", "Role name") { |arg| destroy.role = arg }
     end
 
     parser.on("list", "List cluster roles") do
@@ -268,7 +268,7 @@ op = OptionParser.new do |parser|
       update = set_action RoleUpdate
       parser.banner = "cb role update <--cluster> <--name> [--mode] [--rotate-password]"
       parser.on("--cluster ID", "Choose cluster") { |arg| update.cluster_id = arg }
-      parser.on("--name NAME", "Role name") { |arg| update.role_name = arg }
+      parser.on("--name NAME", "Role name") { |arg| update.role = arg }
       parser.on("--read-only <true|false>", "Read-only") { |arg| update.read_only = arg }
       parser.on("--rotate-password <true|false>", "Rotate password") { |arg| update.rotate_password = arg }
     end


### PR DESCRIPTION
Here we're pulling up common role and role name operations and structures into one place.  We also add a new `role_setter` that also allows us to pull up roll name validation up to when the value is set. This is useful as it we can DRY up some of the role related code as well as simplify some of the test cases.

This will supersede the related changes in #62.