### PR TITLE
Allow `cb psql` to receive team and cluster name.

### DIFF
--- a/spec/cb/cluster_info_spec.cr
+++ b/spec/cb/cluster_info_spec.cr
@@ -10,8 +10,8 @@ Spectator.describe CB::ClusterInfo do
 
   mock Client do
     stub get_cluster(id : Identifier)
-    stub get_team(id)
     stub get_firewall_rules(id)
+    stub get_team(id)
   end
 
   describe "#validate" do

--- a/spec/cb/psql_spec.cr
+++ b/spec/cb/psql_spec.cr
@@ -1,0 +1,68 @@
+require "../spec_helper"
+include CB
+
+Spectator.describe CB::Psql do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  let(client) { Client.new TEST_TOKEN }
+  let(cluster) { Factory.cluster }
+  let(role) { Factory.user_role }
+  let(team) { Factory.team }
+
+  mock Client do
+    stub get_cluster(id : Identifier)
+    stub get_role(id : Identifier, name : String)
+    stub get_team(id)
+    stub get_team_cert(id) { "" }
+  end
+
+  describe "#initialize" do
+    it "ensures 'default' if role not specified" do
+      action.cluster_id = cluster.id
+      expect(&.role.to_s).to eq "default"
+    end
+  end
+
+  describe "#validate" do
+    it "ensures required arguments are present" do
+      expect(&.validate).to raise_error Program::Error, /Missing required argument/
+
+      action.cluster_id = cluster.id
+      expect(&.validate).to be_true
+    end
+  end
+
+  describe "#call" do
+    before_each {
+      # Let's not REALLY call psql.
+      #
+      # TODO (abrightwell): It would be nice if we didn't have to do it this
+      # way. However, it's not evident to me at the time how it's possible to
+      # use `expect(Process).to receive(:exec) ...` for this purpose with
+      # Spectator. Something that perhaps should be followed up on in future
+      # updates.
+      action.psql = Proc(Enumerable(String), Process::Env, NoReturn?).new { nil }
+    }
+
+    # This test gets us through to the point at which the `psql` command is
+    # called.  For obvious reasons we can't go past that, so if we can at least
+    # get to the 'connecting to' message, then we can assert that things up to
+    # that point have been successful and by extension the execution of the
+    # command.
+    it "outputs 'connecting to message'" do
+      action.cluster_id = cluster.id
+
+      expect(client).to receive(:get_cluster).and_return(cluster)
+      expect(client).to receive(:get_role).and_return(role)
+      expect(client).to receive(:get_team).and_return(team)
+
+      action.call
+
+      expected = <<-EXPECTED
+      connecting to #{team.name}/#{cluster.name}\n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+  end
+end

--- a/src/cb/client.cr
+++ b/src/cb/client.cr
@@ -176,6 +176,11 @@ class CB::Client
     Team.from_json resp.body
   end
 
+  def get_team_cert(id)
+    resp = get "teams/#{id}.pem"
+    resp.body
+  end
+
   #
   # Team Members
   #

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -1,77 +1,94 @@
 require "./action"
 
-class CB::Psql < CB::APIAction
-  eid_setter cluster_id
-  property database : String?
-  property role_name : String = "default"
+module CB
+  class Psql < APIAction
+    cluster_identifier_setter cluster_id
+    role_setter role
+    property database : String?
+    setter database
 
-  def run
-    c = client.get_cluster cluster_id
+    # Here we're making it so that we can override the call out to `psql`. This
+    # is for testing purposes only. There should be no need outside of tests to
+    # do this.
+    @psql : Proc(Enumerable(String), Process::Env, NoReturn?)
+    setter psql
 
-    if @role_name == "user"
-      @role_name = "u_#{client.get_account.id}"
+    def initialize(@client, @input = STDIN, @output = STDOUT)
+      @psql = ->(args : Enumerable(String), env : Process::Env) { Process.exec("psql", args, env: env) }
     end
 
-    uri = client.get_role(cluster_id, @role_name).uri
-    raise Error.new "null uri" if uri.nil?
-
-    database.tap { |db| uri.path = db if db }
-
-    output << "connecting to "
-    team_name = print_team_slash_cluster c
-
-    cert_path = ensure_cert c.team_id
-    psqlrc_path = build_psqlrc c, team_name
-
-    args = ARGV.skip 1
-
-    Process.exec("psql", args, env: {
-      "PGHOST"        => uri.hostname,
-      "PGUSER"        => uri.user,
-      "PGPASSWORD"    => uri.password,
-      "PGDATABASE"    => uri.path.lchop('/'),
-      "PGPORT"        => uri.port.to_s,
-      "PSQLRC"        => psqlrc_path,
-      "PGSSLCERT"     => "dontuse",
-      "PGSSLKEY"      => "dontuse",
-      "PGSSLMODE"     => "verify-ca",
-      "PGSSLROOTCERT" => cert_path,
-    })
-  rescue e : File::NotFoundError
-    raise Error.new "The local psql command could not be found"
-  end
-
-  def database=(str : String)
-    @database = str
-  end
-
-  private def ensure_cert(team_id) : String
-    cert_dir = CB::Creds::CONFIG / "certs"
-    path = cert_dir / "#{team_id}.pem"
-    unless File.exists? path
-      Dir.mkdir_p cert_dir
-      File.open(path, "w", perm: 0o600) do |f|
-        f << client.get("teams/#{team_id}.pem").body
+    def validate
+      check_required_args do |missing|
+        missing << "cluster" if @cluster_id.empty?
       end
     end
 
-    path.to_s
-  end
+    def run
+      validate
 
-  private def build_psqlrc(c, team_name) : String
-    psqlpromptname = String.build do |s|
-      s << "%[%033[32m%]#{team_name}%[%033m%]" << "/" if team_name
-      s << "%[%033[36m%]#{c.name}%[%033m%]"
+      c = client.get_cluster cluster_id[:cluster]
+
+      if @role == "user"
+        @role = Role.new "u_#{client.get_account.id}"
+      end
+
+      uri = client.get_role(cluster_id[:cluster], @role.to_s).uri
+      raise Error.new "null uri" if uri.nil?
+
+      database.tap { |db| uri.path = db if db }
+
+      output << "connecting to "
+      team_name = print_team_slash_cluster c
+
+      cert_path = ensure_cert c.team_id
+      psqlrc_path = build_psqlrc c, team_name
+
+      args = ARGV.skip 1
+
+      @psql.call(args, {
+        "PGHOST"        => uri.hostname,
+        "PGUSER"        => uri.user,
+        "PGPASSWORD"    => uri.password,
+        "PGDATABASE"    => uri.path.lchop('/'),
+        "PGPORT"        => uri.port.to_s,
+        "PSQLRC"        => psqlrc_path,
+        "PGSSLCERT"     => "dontuse",
+        "PGSSLKEY"      => "dontuse",
+        "PGSSLMODE"     => "verify-ca",
+        "PGSSLROOTCERT" => cert_path,
+      })
+    rescue e : File::NotFoundError
+      raise Error.new "The local psql command could not be found"
     end
 
-    psqlrc = File.tempfile(c.id, "psqlrc")
-    File.copy("~/.psqlrc", psqlrc.path) if File.exists?("~/.psqlrc")
-    File.open(psqlrc.path, "a") do |f|
-      f.puts "\\set ON_ERROR_ROLLBACK interactive"
-      f.puts "\\set x auto"
-      f.puts "\\set PROMPT1 '#{psqlpromptname}/%[%033[33;1m%]%x%x%x%[%033[0m%]%[%033[1m%]%/%[%033[0m%]%R%# '"
+    private def ensure_cert(team_id) : String
+      cert_dir = CB::Creds::CONFIG / "certs"
+      path = cert_dir / "#{team_id}.pem"
+      unless File.exists? path
+        Dir.mkdir_p cert_dir
+        File.open(path, "w", perm: 0o600) do |f|
+          f << client.get_team_cert team_id
+        end
+      end
+
+      path.to_s
     end
 
-    psqlrc.path.to_s
+    private def build_psqlrc(c, team_name) : String
+      psqlpromptname = String.build do |s|
+        s << "%[%033[32m%]#{team_name}%[%033m%]" << "/" if team_name
+        s << "%[%033[36m%]#{c.name}%[%033m%]"
+      end
+
+      psqlrc = File.tempfile(c.id, "psqlrc")
+      File.copy("~/.psqlrc", psqlrc.path) if File.exists?("~/.psqlrc")
+      File.open(psqlrc.path, "a") do |f|
+        f.puts "\\set ON_ERROR_ROLLBACK interactive"
+        f.puts "\\set x auto"
+        f.puts "\\set PROMPT1 '#{psqlpromptname}/%[%033[33;1m%]%x%x%x%[%033[0m%]%[%033[1m%]%/%[%033[0m%]%R%# '"
+      end
+
+      psqlrc.path.to_s
+    end
   end
 end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -95,7 +95,7 @@ op = OptionParser.new do |parser|
     psql = set_action Psql
 
     parser.on("--database NAME", "Database name (default: postgres)") { |arg| psql.database = arg }
-    parser.on("--role NAME", "Role name (default: default)") { |arg| psql.role_name = arg }
+    parser.on("--role NAME", "Role name (default: default)") { |arg| psql.role = arg }
     positional_args psql.cluster_id
   end
 


### PR DESCRIPTION
Here we're adding the ability to provide a `name` for both a team and a cluster for the `cb psql` command.

The command continues to support providing a cluster id.

Based off of #62 until merged.