### PR TITLE
Update `Spectator` to `0.11.3`.

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.1.0
+    version: 1.3.1
 
   any_hash:
     git: https://github.com/sija/any_hash.cr.git
@@ -10,7 +10,7 @@ shards:
 
   backtracer:
     git: https://github.com/sija/backtracer.cr.git
-    version: 1.2.1
+    version: 1.2.2
 
   db:
     git: https://github.com/crystal-lang/crystal-db.git
@@ -30,7 +30,7 @@ shards:
 
   spectator:
     git: https://gitlab.com/arctic-fox/spectator.git
-    version: 0.10.5
+    version: 0.11.3
 
   ssh2:
     git: https://github.com/spider-gazelle/ssh2.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -16,7 +16,6 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.1.0
   spectator:
     gitlab: arctic-fox/spectator
 

--- a/spec/cb/backup_spec.cr
+++ b/spec/cb/backup_spec.cr
@@ -1,17 +1,11 @@
 require "../spec_helper"
-include CB
 
 Spectator.describe CB::BackupCapture do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
+  mock_client
 
-  mock Client do
-    stub get_cluster(id : Identifier)
-    stub backup_start(id : Identifier)
-    stub get_cluster_by_name(name : Identifier)
-  end
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are present" do
@@ -28,6 +22,7 @@ Spectator.describe CB::BackupCapture do
 
       expect(client).to receive(:get_cluster).and_return(cluster)
       expect(client).to receive(:backup_start).and_return(CB::Client::Message.new)
+
       action.call
 
       expect(&.output.to_s).to match /requested backup capture of /
@@ -38,12 +33,9 @@ end
 Spectator.describe CB::BackupList do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
+  mock_client
 
-  mock Client do
-    stub backup_list(id : Identifier)
-  end
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are presentt" do
@@ -84,12 +76,9 @@ end
 Spectator.describe CB::BackupToken do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
+  mock_client
 
-  mock Client do
-    stub backup_token(id : Identifier)
-  end
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are presentt" do

--- a/spec/cb/cluster_destroy_spec.cr
+++ b/spec/cb/cluster_destroy_spec.cr
@@ -3,13 +3,9 @@ require "../spec_helper"
 Spectator.describe CB::ClusterDestroy do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
+  mock_client
 
-  mock Client do
-    stub get_cluster(id : Identifier)
-    stub destroy_cluster(id)
-  end
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are present" do

--- a/spec/cb/cluster_info_spec.cr
+++ b/spec/cb/cluster_info_spec.cr
@@ -3,15 +3,10 @@ require "../spec_helper"
 Spectator.describe CB::ClusterInfo do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
-  let(team) { Factory.team }
+  mock_client
 
-  mock Client do
-    stub get_cluster(id : Identifier)
-    stub get_firewall_rules(id)
-    stub get_team(id)
-  end
+  let(team) { Factory.team }
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are present" do

--- a/spec/cb/cluster_suspend_resume_spec.cr
+++ b/spec/cb/cluster_suspend_resume_spec.cr
@@ -3,12 +3,9 @@ require "../spec_helper"
 Spectator.describe CB::ClusterSuspend do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
+  mock_client
 
-  mock Client do
-    stub suspend_cluster(id : Identifier)
-  end
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are present" do
@@ -35,12 +32,9 @@ end
 Spectator.describe CB::ClusterResume do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
+  mock_client
 
-  mock Client do
-    stub resume_cluster(id : Identifier)
-  end
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are present" do

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -1,127 +1,93 @@
 require "../spec_helper"
 
-private class ClusterUpgradeTestClient < CB::Client
-  def upgrade_cluster(arg)
-  end
-
-  def upgrade_cluster_cancel(id : String)
-  end
-
-  def upgrade_cluster_status(id : String)
-    Array(Operation).from_json "{\"operations\":[]}", root: "operations"
-  end
-
-  def get_teams
-    teams = [] of Team
-    teams << Team.new(
-      id: "teamid",
-      name: "",
-      is_personal: true,
-      role: "admin",
-    )
-  end
-
-  def get_team(id : String)
-    Team.new(
-      id: "teamid",
-      name: "",
-      is_personal: true,
-      role: "admin",
-    )
-  end
-
-  def get_cluster(id : String)
-    ClusterDetail.new(
-      id: id,
-      team_id: "teamid",
-      name: "source cluster",
-      state: "na",
-      created_at: Time.utc(2016, 2, 15, 10, 20, 30),
-      host: "p.#{id}.test.crunchybridge.com",
-      is_ha: false,
-      major_version: 12,
-      plan_id: "memory-4",
-      cpu: 4,
-      memory: 111,
-      oldest_backup: nil,
-      provider_id: "aws",
-      region_id: "us-east-2",
-      maintenance_window_start: nil,
-      network_id: "nfpvoqooxzdrriu6w3bhqo55c4",
-      storage: 1234
-    )
-  end
-end
-
 Spectator.describe CB::UpgradeStart do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  mock_client
+
+  let(cluster) { Factory.cluster }
+
   it "validates that required arguments are present" do
-    action = CB::UpgradeStart.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
+    expect_missing_arg_error
 
-    msg = /Missing required argument/
-
-    expect_cb_error(msg) { action.validate }
-    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.cluster_id = cluster.id
     action.validate.should eq true
   end
 
   it "#run prints cluster upgrade started" do
-    action = CB::UpgradeStart.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
-    action.output = output = IO::Memory.new
-
-    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.cluster_id = cluster.id
     action.confirmed = true
+
+    expect(client).to receive(:get_cluster).and_return(cluster)
+    expect(client).to receive(:upgrade_cluster).and_return([] of CB::Client::Operation)
 
     action.call
 
-    output.to_s.should eq "  Cluster #{action.cluster_id} upgrade started.\n"
+    expect(&.output.to_s).to eq "  Cluster #{action.cluster_id} upgrade started.\n"
   end
 end
 
 Spectator.describe CB::UpgradeStatus do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  mock_client
+
+  let(cluster) { Factory.cluster }
+  let(team) { Factory.team }
+
   it "validates that required arguments are present" do
-    action = CB::UpgradeStatus.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
+    expect_missing_arg_error
 
-    msg = /Missing required argument/
-
-    expect_cb_error(msg) { action.validate }
-    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    action.cluster_id = cluster.id
     action.validate.should eq true
   end
 
   it "#run no upgrades" do
-    action = CB::UpgradeStatus.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
-    action.output = output = IO::Memory.new
+    action.cluster_id = cluster.id
 
-    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    expect(client).to receive(:get_cluster).and_return(cluster)
+    expect(client).to receive(:get_team).and_return(team)
+    expect(client).to receive(:upgrade_cluster_status).and_return([] of CB::Client::Operation)
 
     action.call
 
-    output.to_s.should eq "personal/source cluster\n  no upgrades in progress\n"
+    expected = <<-EXPECTED
+    #{team.name}/#{cluster.name}
+      no upgrades in progress\n
+    EXPECTED
+
+    expect(&.output.to_s).to eq expected
   end
 end
 
 Spectator.describe CB::UpgradeCancel do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  mock_client
+
+  let(cluster) { Factory.cluster }
+  let(team) { Factory.team }
+
   it "validates that required arguments are present" do
-    action = CB::UpgradeCancel.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
-
-    msg = /Missing required argument/
-
-    expect_cb_error(msg) { action.validate }
-    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    expect_missing_arg_error
+    action.cluster_id = cluster.id
     action.validate.should eq true
   end
 
   it "#run " do
-    action = CB::UpgradeCancel.new(ClusterUpgradeTestClient.new(TEST_TOKEN))
-    action.output = output = IO::Memory.new
+    action.cluster_id = cluster.id
 
-    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    expect(client).to receive(:get_cluster).and_return(cluster)
+    expect(client).to receive(:get_team).and_return(team)
+    expect(client).to receive(:upgrade_cluster_cancel).and_return(HTTP::Client::Response.new(204))
 
     action.call
 
-    expected = "personal/source cluster\n"
-    expected += "  upgrade cancelled\n"
+    expected = <<-EXPECTED
+    #{team.name}/#{cluster.name}
+      upgrade cancelled\n
+    EXPECTED
 
-    output.to_s.should eq expected
+    expect(&.output.to_s).to eq expected
   end
 end

--- a/spec/cb/cluster_uri_spec.cr
+++ b/spec/cb/cluster_uri_spec.cr
@@ -4,15 +4,11 @@ include CB
 Spectator.describe CB::ClusterURI do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
+  mock_client
+
   let(account) { Factory.account }
-  let(client) { Client.new TEST_TOKEN }
   let(cluster) { Factory.cluster }
   let(role) { Factory.user_role }
-
-  mock Client do
-    stub get_account
-    stub get_role(cluster_id, role_name)
-  end
 
   describe "#initialize" do
     it "ensures 'default' if role not specified" do
@@ -32,7 +28,6 @@ Spectator.describe CB::ClusterURI do
 
   describe "#call" do
     it "output default format" do
-      action.output = IO::Memory.new
       action.cluster_id = cluster.id
       action.role = "user"
 

--- a/spec/cb/detach_spec.cr
+++ b/spec/cb/detach_spec.cr
@@ -3,13 +3,9 @@ require "../spec_helper"
 Spectator.describe CB::Detach do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
+  mock_client
 
-  mock Client do
-    stub get_cluster(id : Identifier)
-    stub detach_cluster(id : Identifier)
-  end
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are present" do

--- a/spec/cb/logdest_add_spec.cr
+++ b/spec/cb/logdest_add_spec.cr
@@ -7,31 +7,30 @@ private def make_lda
   CB::LogDestinationAdd.new(LogDestinationAddTestClient.new(TEST_TOKEN))
 end
 
-private def expect_validation_err(lda, part)
-  expect_cb_error(/Missing required argument.+#{part}/) { lda.validate }
-end
-
 Spectator.describe CB::LogDestinationAdd do
-  it "validates that required arguments are present" do
-    lda = make_lda
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-    expect_validation_err lda, "cluster"
-    lda.cluster_id = "afpvoqooxzdrriu6w3bhqo55c4"
-    expect_validation_err lda, "port"
-    lda.port = 2345
-    expect_validation_err lda, "desc"
-    lda.description = "hello"
-    expect_validation_err lda, "host"
-    lda.host = "example.com"
-    expect_validation_err lda, "template"
-    lda.template = "some stuff"
-    lda.validate.should eq true
-  end
+  mock_client
 
-  it "only allows valid eids for cluster arg" do
-    lda = make_lda
-    lda.cluster_id = "afpvoqooxzdrriu6w3bhqo55c4"
-    expect_cb_error(/cluster id/) { lda.cluster_id = "notaneid" }
+  let(cluster) { Factory.cluster }
+
+  it "ensures required arguments are present" do
+    expect_missing_arg_error
+    action.cluster_id = cluster.id
+
+    expect_missing_arg_error
+    action.port = 2345
+
+    expect_missing_arg_error
+    action.description = "hello"
+
+    expect_missing_arg_error
+    action.host = "example.com"
+
+    expect_missing_arg_error
+    action.template = "some stuff"
+
+    expect(&.validate).to be_true
   end
 
   it "sets a default description based on the host if missing" do

--- a/spec/cb/maintenance_spec.cr
+++ b/spec/cb/maintenance_spec.cr
@@ -7,10 +7,7 @@ Spectator.describe MaintenanceInfo do
   let(cluster) { Factory.cluster }
   let(team) { Factory.team }
 
-  mock Client do
-    stub get_cluster(id : Identifier)
-    stub get_team(id)
-  end
+  mock_client
 
   it "validates that required arguments are present" do
     expect(&.validate).to raise_error Program::Error, /Missing required argument/
@@ -35,9 +32,7 @@ Spectator.describe MaintenanceUpdate do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
   let(client) { Client.new TEST_TOKEN }
 
-  mock Client do
-    stub update_cluster(id, body)
-  end
+  mock_client
 
   it "validates that required arguments are present" do
     expect(&.validate).to raise_error Program::Error, /Missing required argument: cluster/

--- a/spec/cb/psql_spec.cr
+++ b/spec/cb/psql_spec.cr
@@ -4,17 +4,15 @@ include CB
 Spectator.describe CB::Psql do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
+  mock_client do
+    def get_team_cert(team : String)
+      ""
+    end
+  end
+
   let(cluster) { Factory.cluster }
   let(role) { Factory.user_role }
   let(team) { Factory.team }
-
-  mock Client do
-    stub get_cluster(id : Identifier)
-    stub get_role(id : Identifier, name : String)
-    stub get_team(id)
-    stub get_team_cert(id) { "" }
-  end
 
   describe "#initialize" do
     it "ensures 'default' if role not specified" do

--- a/spec/cb/restart_spec.cr
+++ b/spec/cb/restart_spec.cr
@@ -3,13 +3,9 @@ require "../spec_helper"
 Spectator.describe CB::Restart do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
+  mock_client
 
-  mock Client do
-    stub get_cluster(id : Identifier)
-    stub restart_cluster(id, service : String)
-  end
+  let(cluster) { Factory.cluster }
 
   describe "#validate" do
     it "ensures required arguments are present" do

--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -1,15 +1,11 @@
 require "../spec_helper"
-include CB
 
 Spectator.describe RoleCreate do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
-  let(client) { Client.new TEST_TOKEN }
+
+  mock_client
 
   let(user_role) { Factory.user_role }
-
-  mock Client do
-    stub create_role(id)
-  end
 
   it "validates that required arguments are present" do
     expect(&.validate).to raise_error Program::Error, /Missing required argument/
@@ -22,7 +18,7 @@ Spectator.describe RoleCreate do
     action.output = IO::Memory.new
     action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
 
-    expect(client).to receive(:create_role).with(action.cluster_id).and_return user_role
+    expect(client).to receive(:create_role).and_return user_role
 
     action.call
 
@@ -33,16 +29,11 @@ end
 Spectator.describe RoleList do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(client) { Client.new TEST_TOKEN }
+  mock_client
+
   let(roles) { [Factory.system_role, Factory.user_role] }
   let(team) { Factory.team }
   let(cluster) { Factory.cluster }
-
-  mock Client do
-    stub list_roles(id)
-    stub get_cluster(id : String?)
-    stub get_team(id)
-  end
 
   it "validates that required arguments are present" do
     expect(&.validate).to raise_error Program::Error, /Missing required argument/
@@ -55,9 +46,9 @@ Spectator.describe RoleList do
     action.output = IO::Memory.new
     action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
 
-    expect(client).to receive(:get_cluster).with(action.cluster_id).and_return cluster
-    expect(client).to receive(:get_team).with(cluster.team_id).and_return team
-    expect(client).to receive(:list_roles).with(action.cluster_id).and_return roles
+    expect(client).to receive(:get_cluster).and_return cluster
+    expect(client).to receive(:get_team).and_return team
+    expect(client).to receive(:list_roles).and_return roles
 
     action.call
 
@@ -81,9 +72,9 @@ Spectator.describe RoleList do
     action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.format = CB::RoleList::Format::JSON
 
-    expect(client).to receive(:get_cluster).with(action.cluster_id).and_return cluster
-    expect(client).to receive(:get_team).with(cluster.team_id).and_return team
-    expect(client).to receive(:list_roles).with(action.cluster_id).and_return roles
+    expect(client).to receive(:get_cluster).and_return cluster
+    expect(client).to receive(:get_team).and_return team
+    expect(client).to receive(:list_roles).and_return roles
 
     action.call
 
@@ -111,13 +102,10 @@ end
 Spectator.describe RoleUpdate do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(account) { Factory.account }
-  let(client) { Client.new TEST_TOKEN }
+  mock_client
 
-  mock Client do
-    stub get_account { Factory.account }
-    stub update_role(cluster_id, role_name, ur) { Factory.user_role }
-  end
+  let(account) { Factory.account }
+  let(role) { Factory.user_role }
 
   describe "#validate" do
     it "validates that required arguments are present" do
@@ -140,6 +128,7 @@ Spectator.describe RoleUpdate do
 
     it "prints confirmation" do
       expect(client).to receive(:get_account).and_return account
+      expect(client).to receive(:update_role).and_return role
       action.call
       expect(&.output.to_s).to eq "Role #{action.role} updated on cluster #{action.cluster_id}.\n"
     end
@@ -149,13 +138,10 @@ end
 Spectator.describe RoleDelete do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-  let(account) { Factory.account }
-  let(client) { Client.new TEST_TOKEN }
+  mock_client
 
-  mock Client do
-    stub delete_role(cluster_id, role_name) { Factory.user_role }
-    stub get_account
-  end
+  let(account) { Factory.account }
+  let(role) { Factory.user_role }
 
   describe "#validate" do
     it "ensures required arguments are present" do
@@ -178,6 +164,7 @@ Spectator.describe RoleDelete do
 
     it "prints confirmation" do
       expect(client).to receive(:get_account).and_return account
+      expect(client).to receive(:delete_role).and_return role
 
       action.call
 

--- a/spec/cb/tailscale_spec.cr
+++ b/spec/cb/tailscale_spec.cr
@@ -5,9 +5,7 @@ Spectator.describe TailscaleConnect do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
   let(client) { Client.new TEST_TOKEN }
 
-  mock Client do
-    stub put(path, body)
-  end
+  mock_client
 
   it "validates that required arguments are present" do
     expect(&.validate).to raise_error Program::Error, /Missing required argument/
@@ -33,9 +31,7 @@ Spectator.describe TailscaleDisconnect do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
   let(client) { Client.new TEST_TOKEN }
 
-  mock Client do
-    stub put(path, body = nil) # ameba:disable Lint/UselessAssign
-  end
+  mock_client
 
   it "validates that required arguments are present" do
     expect(&.validate).to raise_error Program::Error, /Missing required argument/

--- a/spec/cb/team_member_spec.cr
+++ b/spec/cb/team_member_spec.cr
@@ -1,94 +1,46 @@
 require "../spec_helper"
 
-private class TeamMemberTestClient < CB::Client
-  MEMBERS = [
-    CB::Client::TeamMember.new(
-      id: "abc",
-      team_id: "pkdpq6yynjgjbps4otxd7il2u4",
-      account_id: "4pfqoxothfagnfdryk2og7noei",
-      role: "member",
-      email: "test@example.com",
-    ),
-  ]
-
-  def get_team(team_id)
-    Team.new(
-      id: "pkdpq6yynjgjbps4otxd7il2u4",
-      name: "Test Team",
-      is_personal: false,
-      role: nil,
-      billing_email: nil,
-      enforce_sso: nil,
-    )
-  end
-
-  def create_team_member(team_id, params : TeamMemberCreateParams)
-    TeamMember.new(
-      id: "",
-      team_id: team_id.to_s,
-      account_id: "abc123",
-      role: params.role,
-      email: params.email,
-    )
-  end
-
-  def get_team_member(team_id, account_id)
-    MEMBERS[0]
-  end
-
-  def list_team_members(team_id)
-    MEMBERS
-  end
-
-  def update_team_member(team_id, account_id, role)
-    MEMBERS[0]
-  end
-
-  def remove_team_member(team_id, account_id)
-    MEMBERS[0]
-  end
-end
-
 Spectator.describe CB::TeamMemberAdd do
-  it "validates that required arguments are present" do
-    action = CB::TeamMemberAdd.new(TeamMemberTestClient.new(TEST_TOKEN))
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
 
-    msg = /Missing required argument/
-    expect_cb_error(msg) { action.validate }
+  mock_client
+
+  it "validates that required arguments are present" do
+    expect_missing_arg_error
 
     action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.email = "test@example.com"
-    action.validate.should eq true
+    expect(&.validate).to be_true
 
     action.role = "some role"
     msg = /invalid role '#{action.role}'/
-    expect_cb_error(msg) { action.validate }
+    expect(&.validate).to raise_error(Program::Error, msg)
   end
 
   it "#run prints confirmation" do
-    action = CB::TeamMemberAdd.new(TeamMemberTestClient.new(TEST_TOKEN))
-    action.output = output = IO::Memory.new
+    expect(client).to receive(:create_team_member).and_return(Factory.team_member)
 
     action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.email = "test@example.com"
 
     action.call
 
-    output.to_s.should eq "Added #{action.email} to team #{action.team_id} as role 'member'.\n"
+    expect(&.output.to_s).to eq "Added #{action.email} to team #{action.team_id} as role 'member'.\n"
   end
 end
 
 Spectator.describe CB::TeamMemberInfo do
-  it "validates that required arguments are present" do
-    action = CB::TeamMemberInfo.new(TeamMemberTestClient.new(TEST_TOKEN))
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
 
+  mock_client
+
+  it "validates that required arguments are present" do
     msg = /Missing required argument/
-    expect_cb_error(msg) { action.call }
+    expect(&.call).to raise_error(Program::Error, msg)
   end
 
   it "#run prints unknown member" do
-    action = CB::TeamMemberInfo.new(TeamMemberTestClient.new(TEST_TOKEN))
-    action.output = output = IO::Memory.new
+    expect(client).to receive(:list_team_members).and_return([Factory.team_member])
 
     action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.email = "unknown@example.com"
@@ -96,21 +48,22 @@ Spectator.describe CB::TeamMemberInfo do
     action.call
 
     expected = "Unknown team member.\n"
-    output.to_s.should eq expected
+    expect(&.output.to_s).to eq expected
   end
 end
 
 Spectator.describe CB::TeamMemberList do
-  it "validates that required arguments are present" do
-    action = CB::TeamMemberList.new(TeamMemberTestClient.new(TEST_TOKEN))
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
 
+  mock_client
+
+  it "validates that required arguments are present" do
     msg = /Missing required argument/
-    expect_cb_error(msg) { action.call }
+    expect(&.call).to raise_error(Program::Error, msg)
   end
 
   it "#run" do
-    action = CB::TeamMemberList.new(TeamMemberTestClient.new(TEST_TOKEN))
-    action.output = IO::Memory.new
+    expect(client).to receive(:list_team_members).and_return([Factory.team_member])
 
     action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.call.should be nil
@@ -119,101 +72,105 @@ Spectator.describe CB::TeamMemberList do
 end
 
 Spectator.describe CB::TeamMemberUpdate do
-  it "validates that required arguments are present" do
-    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
 
+  mock_client
+
+  it "validates that required arguments are present" do
     msg = /Missing required argument/
-    expect_cb_error(msg) { action.call }
+    expect(&.call).to raise_error(Program::Error, msg)
   end
 
   it "validates argument conflicts" do
-    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
-
     action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.account_id = "4pfqoxothfagnfdryk2og7noei"
     action.email = "test@example.com"
 
     msg = /Must only use '--account' or '--email' but not both./
-    expect_cb_error(msg) { action.call }
+    expect(&.call).to raise_error(Program::Error, msg)
   end
 
-  it "#run" do
-    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
-    action.output = IO::Memory.new
+  describe "#run" do
+    before_each {
+      expect(client).to receive(:update_team_member).and_return(Factory.team_member)
+    }
 
-    # TODO (abrightwell): There's got to be a better way to test the output. For
-    # instance, more intelligently checking the value of the content, instead of
-    # just doing a simple string comparison. Perhaps revisiting this at some
-    # point would be appropriate?
-    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
-    action.account_id = "4pfqoxothfagnfdryk2og7noei"
-    action.call.should_not be nil
-    action.output.to_s.should_not eq ""
+    it "#updates with account id" do
+      action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+      action.account_id = "4pfqoxothfagnfdryk2og7noei"
+      action.call.should_not be nil
+      action.output.to_s.should_not eq ""
+    end
 
-    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
-    action.output = IO::Memory.new
-
-    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
-    action.email = "test@example.com"
-    action.call.should_not be nil
-    action.output.to_s.should_not eq ""
+    it "updates with acount email" do
+      expect(client).to receive(:list_team_members).and_return([Factory.team_member])
+      action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+      action.email = "test@example.com"
+      action.call.should_not be nil
+      action.output.to_s.should_not eq ""
+    end
   end
 
   it "#run unknown team member" do
-    action = CB::TeamMemberUpdate.new(TeamMemberTestClient.new(TEST_TOKEN))
-
     action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.email = "unknown@example.com"
 
+    expect(client).to receive(:list_team_members).and_return([Factory.team_member])
+
     msg = /Unknown team member/
-    expect_cb_error(msg) { action.call }
+    expect(&.call).to raise_error(Program::Error, msg)
   end
 end
 
 Spectator.describe CB::TeamMemberRemove do
-  it "validates that required arguments are present" do
-    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
 
+  mock_client
+
+  it "validates that required arguments are present" do
     msg = /Missing required argument/
-    expect_cb_error(msg) { action.call }
+    expect(&.call).to raise_error(Program::Error, msg)
   end
 
   it "validates argument conflicts" do
-    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
-
     action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.account_id = "4pfqoxothfagnfdryk2og7noei"
     action.email = "test@example.com"
 
     msg = /Must only use '--account' or '--email' but not both./
-    expect_cb_error(msg) { action.call }
+    expect(&.call).to raise_error(Program::Error, msg)
   end
 
-  it "#run" do
-    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
-    action.output = IO::Memory.new
+  describe "#run" do
+    before_each {
+      expect(client).to receive(:remove_team_member).and_return(Factory.team_member)
+      expect(client).to receive(:get_team).and_return(Factory.team)
 
-    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
-    action.account_id = "4pfqoxothfagnfdryk2og7noei"
-    action.call.should_not be nil
-    action.output.to_s.should_not eq ""
+      action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
+    }
 
-    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
-    action.output = IO::Memory.new
+    it "removes with account id" do
+      action.account_id = "4pfqoxothfagnfdryk2og7noei"
+      action.call.should_not be nil
+      action.output.to_s.should_not eq ""
+    end
 
-    action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
-    action.email = "test@example.com"
-    action.call.should_not be nil
-    action.output.to_s.should_not eq ""
+    it "removes with account email" do
+      expect(client).to receive(:list_team_members).and_return([Factory.team_member])
+
+      action.email = "test@example.com"
+      action.call.should_not be nil
+      action.output.to_s.should_not eq ""
+    end
   end
 
   it "#run unknown team member" do
-    action = CB::TeamMemberRemove.new(TeamMemberTestClient.new(TEST_TOKEN))
+    expect(client).to receive(:list_team_members).and_return([Factory.team_member])
 
     action.team_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.email = "unknown@example.com"
 
     msg = /Unknown team member/
-    expect_cb_error(msg) { action.call }
+    expect(&.call).to raise_error(Program::Error, msg)
   end
 end

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -114,6 +114,18 @@ module Factory
     CB::Client::Team.new **params
   end
 
+  def team_member(**params)
+    params = {
+      id:         "abc",
+      team_id:    "pkdpq6yynjgjbps4otxd7il2u4",
+      account_id: "4pfqoxothfagnfdryk2og7noei",
+      role:       "member",
+      email:      "test@example.com",
+    }.merge(params)
+
+    CB::Client::TeamMember.new **params
+  end
+
   def tempkey(**params)
     params = {
       private_key: "private_key",

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,6 @@
 require "../src/cb"
 require "./factory"
-require "spec"
+# require "spec"
 require "spectator"
 require "spectator/should"
 
@@ -9,6 +9,34 @@ include CB
 Colorize.enabled = false
 TEST_TOKEN = CB::Token.new("localhost", "token", Time.local.to_unix + 1.hour.seconds, "userid", "user name")
 
-def expect_cb_error(message, file = __FILE__, line = __LINE__)
-  expect_raises(CB::Program::Error, message, file: file, line: line) { yield }
+macro expect_cb_error(message)
+  expect({{ yield }}).to raise_error(CB::Program::Error, {{message}})
+end
+
+macro expect_missing_arg_error
+  expect(&.validate).to raise_error(CB::Program::Error, /Missing required argument/)
+end
+
+macro expect_invalid_arg_error
+  expect({{yield}}).to raise_error(CB::Program::Error, /Invalid/)
+end
+
+macro mock_client
+  mock Client do
+    def initialize(@token : Token = TEST_TOKEN)
+    end
+
+    {{ yield }}
+  end
+
+  let(client) { mock(Client) }
+end
+
+def invalid_ids
+  [
+    "yes",
+    "afpvoqooxzdrriu6w3bhqo55c3",
+    "aafpvoqooxzdrriu6w3bhqo55c4",
+    "fpvoqooxzdrriu6w3bhqo55c4",
+  ]
 end

--- a/src/cb/types.cr
+++ b/src/cb/types.cr
@@ -11,10 +11,10 @@ module CB
     end
 
     def initialize(@name : String = "default")
-      raise Program::Error.new INVALID_ROLE_MESSAGE % @name unless is_valid?
+      raise Program::Error.new INVALID_ROLE_MESSAGE % @name unless valid?
     end
 
-    def is_valid?
+    def valid?
       return true if EID_PATTERN.matches? @name.lchop("u_")
       VALID_CLUSTER_ROLES.includes? @name
     end

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -70,19 +70,19 @@ module CB
     end
 
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clusters/post
-    def create_cluster(cc)
-      body = {
-        is_ha:               cc.ha,
-        name:                cc.name,
-        plan_id:             cc.plan,
-        provider_id:         cc.platform,
-        postgres_version_id: cc.postgres_version,
-        region_id:           cc.region,
-        storage:             cc.storage,
-        team_id:             cc.team,
-        network_id:          cc.network,
-      }
-      resp = post "clusters", body
+    def create_cluster(params)
+      # body = {
+      #   is_ha:               cc.ha,
+      #   name:                cc.name,
+      #   plan_id:             cc.plan,
+      #   provider_id:         cc.platform,
+      #   postgres_version_id: cc.postgres_version,
+      #   region_id:           cc.region,
+      #   storage:             cc.storage,
+      #   team_id:             cc.team,
+      #   network_id:          cc.network,
+      # }
+      resp = post "clusters", params
       Cluster.from_json resp.body
     end
 


### PR DESCRIPTION
This is a pretty large changeset due in part to the breaking changes that were introduced by this update.

We also take the opportunity to go ahead and transition the remaining tests to bring them in line.

There were some interesting challenges. Mostly around how the create cluster action behaves. Specifically, it's the related client calls that caused a bit of a head ache. For some reason, Spectator doesn't like how we were doing it. And when stubbing the `create_cluster` method, things 'worked' (verified by tracing the call), but for some reason it would cause a crash elsewhere that was quite annoying. I believe it's possible that there is an issue in Spectator around this. However, I was unable to pin point it. However, I'm not terribly concerned with it as making the transition on these client methods has been on the TODO list for some time. So, we're also taking that opportunity with these changes.