### PR TITLE
Upgrade to `ameba` 1.1.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,11 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    container: crystallang/crystal:latest-alpine
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
-    - name: Add Crystal repos
-      run: curl -sSL https://crystal-lang.org/install.sh | sudo bash
-
-    - name: Install crystal
-      run: sudo apt-get install -y crystal libevent-dev libpcre3-dev libreadline-dev
 
     - name: Format
       run: crystal tool format --check

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.0.0
+    version: 1.1.0
 
   any_hash:
     git: https://github.com/sija/any_hash.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -16,7 +16,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.0.0
+    version: ~> 1.1.0
   spectator:
     gitlab: arctic-fox/spectator
 


### PR DESCRIPTION
Crystal 1.6.0 is now available. But that causes issue with `ameba`. Unfortunately, 1.5.1 is no longer available from homebrew... or at least not easily. However, it seems like going from `ameba` 1.0.0 to 1.1.0 seems to resolve the issue, for now.