### PR TITLE
Info and cancel on maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `cb upgrade status` returns maintenance window information
+- `cb maintenance` command now supports `cancel` 
 
 ## [3.1.0] - 2022-11-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cb upgrade status` returns maintenance window information
 
 ## [3.1.0] - 2022-11-18
 ### Added

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -59,6 +59,43 @@ Spectator.describe CB::UpgradeStatus do
 
     expect(&.output.to_s).to eq expected
   end
+
+  it "#run display ha operation by default" do
+    action.cluster_id = cluster.id
+
+    expect(client).to receive(:get_cluster).and_return(cluster)
+    expect(client).to receive(:get_team).and_return(team)
+    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("ha_change", "fake")])
+
+    action.call
+
+    expected = <<-EXPECTED
+    #{team.name}/#{cluster.name}
+      maintenance window: no window set. Default to: 00:00-23:59
+               ha_change: fake\n
+    EXPECTED
+
+    expect(&.output.to_s).to eq expected
+  end
+
+  it "#run filter ha operation if told so" do
+    action.cluster_id = cluster.id
+    action.maintenance_only = true
+
+    expect(client).to receive(:get_cluster).and_return(cluster)
+    expect(client).to receive(:get_team).and_return(team)
+    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("ha_change", "fake")])
+
+    action.call
+
+    expected = <<-EXPECTED
+    #{team.name}/#{cluster.name}
+      no maintenance operations in progress
+      maintenance window: no window set. Default to: 00:00-23:59\n
+    EXPECTED
+
+    expect(&.output.to_s).to eq expected
+  end
 end
 
 Spectator.describe CB::UpgradeCancel do

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -53,7 +53,8 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      no operations in progress\n
+      no operations in progress
+      maintenance window: no window set. Default to: 00:00-23:59\n
     EXPECTED
 
     expect(&.output.to_s).to eq expected

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -53,7 +53,7 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      no upgrades in progress\n
+      no operations in progress\n
     EXPECTED
 
     expect(&.output.to_s).to eq expected
@@ -85,7 +85,7 @@ Spectator.describe CB::UpgradeCancel do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      upgrade cancelled\n
+      operation cancelled\n
     EXPECTED
 
     expect(&.output.to_s).to eq expected

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -501,11 +501,18 @@ Spectator.describe CB::Completion do
     result = parse("cb maintenance ")
     expect(result).to have_option "info"
     expect(result).to have_option "update"
+    expect(result).to have_option "cancel"
 
     result = parse("cb maintenance info ")
     expect(result).to have_option "--cluster"
 
     result = parse("cb maintenance info --cluster ")
+    expect(result).to eq ["abc\tmy team/my cluster"]
+
+    result = parse("cb maintenance cancel ")
+    expect(result).to have_option "--cluster"
+
+    result = parse("cb maintenance cancel --cluster ")
     expect(result).to eq ["abc\tmy team/my cluster"]
 
     result = parse "cb maintenance update "

--- a/spec/cb/maintenance_spec.cr
+++ b/spec/cb/maintenance_spec.cr
@@ -1,33 +1,6 @@
 require "../spec_helper"
 include CB
 
-Spectator.describe MaintenanceInfo do
-  subject(action) { described_class.new client: client, output: IO::Memory.new }
-  let(client) { Client.new TEST_TOKEN }
-  let(cluster) { Factory.cluster }
-  let(team) { Factory.team }
-
-  mock_client
-
-  it "validates that required arguments are present" do
-    expect(&.validate).to raise_error Program::Error, /Missing required argument/
-
-    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
-
-    expect(&.validate).to be_true
-  end
-
-  it "#run makes an api call" do
-    action.output = IO::Memory.new
-    action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
-
-    expect(client).to receive(:get_cluster).with(action.cluster_id[:cluster]).and_return cluster
-    expect(client).to receive(:get_team).with(cluster.team_id).and_return team
-
-    action.call
-  end
-end
-
 Spectator.describe MaintenanceUpdate do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
   let(client) { Client.new TEST_TOKEN }

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -64,15 +64,22 @@ class CB::UpgradeStatus < CB::Upgrade
     print_team_slash_cluster c
 
     operations = client.upgrade_cluster_status cluster_id
+    details = {
+      "maintenance window" => MaintenanceWindow.new(c.maintenance_window_start).explain,
+    }
+
+    operations.each do |op|
+      details[op.flavor] = op.state
+    end
 
     if operations.empty?
       output << "  no operations in progress\n".colorize.bold
-    else
-      pad = (operations.map(&.flavor.size).max || 8) + 2
-      operations.each do |op|
-        output << op.flavor.rjust(pad).colorize.bold << ": "
-        output << op.state << "\n"
-      end
+    end
+
+    pad = (details.keys.map(&.size).max || 8) + 2
+    details.each do |k, v|
+      output << k.rjust(pad).colorize.bold << ": "
+      output << v << '\n'
     end
   end
 end

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -51,7 +51,7 @@ class CB::UpgradeCancel < CB::Upgrade
     print_team_slash_cluster c
 
     client.upgrade_cluster_cancel cluster_id
-    output << "  upgrade cancelled\n".colorize.bold
+    output << "  operation cancelled\n".colorize.bold
   end
 end
 
@@ -66,7 +66,7 @@ class CB::UpgradeStatus < CB::Upgrade
     operations = client.upgrade_cluster_status cluster_id
 
     if operations.empty?
-      output << "  no upgrades in progress\n".colorize.bold
+      output << "  no operations in progress\n".colorize.bold
     else
       pad = (operations.map(&.flavor.size).max || 8) + 2
       operations.each do |op|

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -328,7 +328,7 @@ class CB::Completion
   def maintenance
     case @args[1]
     when "info"
-      maintenance_info
+      upgrade_status
     when "update"
       maintenance_update
     else
@@ -337,18 +337,6 @@ class CB::Completion
         "update\tupdate cluster maintenance",
       ]
     end
-  end
-
-  def maintenance_info : Array(String)
-    return ["--cluster\tcluster id"] if @args.size == 3
-
-    cluster = find_arg_value "--cluster"
-
-    if last_arg?("--cluster")
-      return cluster.nil? ? cluster_suggestions : [] of String
-    end
-
-    suggest_none
   end
 
   def maintenance_update : Array(String)

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -331,10 +331,13 @@ class CB::Completion
       upgrade_status
     when "update"
       maintenance_update
+    when "cancel"
+      upgrade_cancel
     else
       [
         "info\tdetailed cluster maintenance information",
         "update\tupdate cluster maintenance",
+        "cancel\tcancel a cluster maintenance",
       ]
     end
   end

--- a/src/cb/maintenance.cr
+++ b/src/cb/maintenance.cr
@@ -8,18 +8,6 @@ abstract class CB::MaintenanceAction < CB::APIAction
   end
 end
 
-# Action to get cluster maintenance information
-class CB::MaintenanceInfo < CB::MaintenanceAction
-  def run
-    validate
-
-    c = client.get_cluster(cluster_id[:cluster])
-    print_team_slash_cluster c
-
-    output << "maintenance window: " << MaintenanceWindow.new(c.maintenance_window_start).explain
-  end
-end
-
 # Action to update cluster maintenance window
 class CB::MaintenanceUpdate < CB::MaintenanceAction
   i32_setter window_start

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -245,9 +245,9 @@ op = OptionParser.new do |parser|
     parser.banner = "cb maintenance <info|update>"
 
     parser.on("info", "Detailed cluster maintenance information") do
-      info = set_action MaintenanceInfo
+      upgrade = set_action UpgradeStatus
       parser.banner = "cb maintenance info <--cluster>"
-      parser.on("--cluster ID", "Choose cluster") { |arg| info.cluster_id = arg }
+      parser.on("--cluster ID", "Choose cluster") { |arg| upgrade.cluster_id = arg }
     end
 
     parser.on("update", "Update cluster maintenance") do

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -250,6 +250,13 @@ op = OptionParser.new do |parser|
       parser.on("--cluster ID", "Choose cluster") { |arg| upgrade.cluster_id = arg }
     end
 
+    parser.on("cancel", "Cancel a cluster maintenance") do
+      upgrade = set_action UpgradeCancel
+      parser.banner = "cb maintenance cancel <--cluster>"
+
+      parser.on("--cluster ID", "Choose cluster") { |arg| upgrade.cluster_id = arg }
+    end
+
     parser.on("update", "Update cluster maintenance") do
       update = set_action MaintenanceUpdate
       parser.banner = "cb maintenance update <--cluster> [--window-start] [--unset]"

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -246,6 +246,8 @@ op = OptionParser.new do |parser|
 
     parser.on("info", "Detailed cluster maintenance information") do
       upgrade = set_action UpgradeStatus
+      upgrade.maintenance_only = true
+
       parser.banner = "cb maintenance info <--cluster>"
       parser.on("--cluster ID", "Choose cluster") { |arg| upgrade.cluster_id = arg }
     end


### PR DESCRIPTION
This PR updates `cb upgrade` to be more abstract so that it can be used inside maintenance