### PR TITLE
Fix `--network` not being honored by `cb create --replica`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `cb upgrade status` returns maintenance window information
-- `cb maintenance` command now supports `cancel` 
+- `cb maintenance` command now supports `cancel`
+
+### Fixed
+- Fix `--network` not being honored when passed with `cb create --replica`.
 
 ## [3.1.0] - 2022-11-18
 ### Added

--- a/spec/cb/cluster_create_spec.cr
+++ b/spec/cb/cluster_create_spec.cr
@@ -123,7 +123,52 @@ Spectator.describe CB::ClusterCreate do
     end
   end
 
-  describe "#call - replica", skip: "Not implemented yet" do
+  describe "#call - replica" do
+    before_each {
+      expect(client).to receive(:get_cluster).and_return(cluster)
+    }
+
+    it "fills in defaults from the source cluster" do
+      expect(&.name).to be_nil
+      expect(&.platform).to be_nil
+      expect(&.region).to be_nil
+      expect(&.storage).to be_nil
+      expect(&.plan).to be_nil
+      expect(&.network).to be_nil
+
+      action.fork = cluster.id
+      expect(&.pre_validate).to_not raise_error
+
+      expect(&.name).to eq "Fork of abc"
+      expect(&.platform).to eq "aws"
+      expect(&.region).to eq "us-east-2"
+      expect(&.storage).to eq 1234
+      expect(&.plan).to eq "memory-4"
+      expect(&.network).to eq cluster.network_id
+
+      expect(&.validate).to be_true
+    end
+
+    it "does not overwrite values given with defaults from source cluster" do
+      action.fork = cluster.id
+      action.name = "given name"
+      action.platform = "gcp"
+      action.region = "centralus"
+      action.plan = "cpu-100"
+      action.storage = 4321
+      action.network = "cywdcbebozfczpsnl2ha643m3e"
+
+      expect(&.pre_validate).to_not raise_error
+
+      expect(&.name).to eq "given name"
+      expect(&.platform).to eq "gcp"
+      expect(&.region).to eq "centralus"
+      expect(&.plan).to eq "cpu-100"
+      expect(&.storage).to eq 4321
+      expect(&.network).to eq "cywdcbebozfczpsnl2ha643m3e"
+
+      expect(&.validate).to be_true
+    end
   end
 
   describe "#call - fork" do

--- a/src/cb/cluster_create.cr
+++ b/src/cb/cluster_create.cr
@@ -23,6 +23,7 @@ class CB::ClusterCreate < CB::APIAction
       @region ||= source.region_id
       @storage ||= source.storage
       @plan ||= source.plan_id
+      @network ||= source.network_id
     else
       @storage ||= 100
       @name ||= "Cluster #{Time.utc.to_s("%F %H_%M_%S")}"

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -134,12 +134,14 @@ module CB
       ClusterDetail.from_json resp.body
     end
 
+    # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridreplicas/create-cluster-replica
     def replicate_cluster(cc)
       resp = post "clusters/#{cc.replica}/replicas", {
         name:        cc.name,
         plan_id:     cc.plan,
         provider_id: cc.platform,
         region_id:   cc.region,
+        network_id:  cc.network,
       }
       Cluster.from_json resp.body
     end


### PR DESCRIPTION
Previously, `--network` was an allowed option when creating a replica. At the time it wasn't supported by the API and shouldn't have been a valid option. However, since then the API now supports it. So, here we're simply fixing `cb create --replica` to honor the values it's passed for this option.  If no option is passed it will default to the source cluster.