### PR TITLE
Schedule maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `cb maintenance` command now supports `cancel`
+- `cb maintenance` command now supports `cancel` and `create`
 - `cb network` command added to manage networks. Supports `list` and `info`.
 - `cb upgrade status` returns maintenance window information
 - `cb upgrade start` command accepts `--starting-from` and `--now` options that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix `--network` not being honored when passed with `cb create --replica`.
+- `cb upgrade start` don't change `ha` by default.
 
 ## [3.1.0] - 2022-11-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cb maintenance` command now supports `cancel`
 - `cb network` command added to manage networks. Supports `list` and `info`.
 - `cb upgrade status` returns maintenance window information
+- `cb upgrade start` command accepts `--starting-from` and `--now` options that
+   specify upgrade failover window.
 
 ### Fixed
 - Fix `--network` not being honored when passed with `cb create --replica`.

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -818,6 +818,8 @@ Spectator.describe CB::Completion do
     expect(result).to have_option "--ha"
     expect(result).to have_option "--plan"
     expect(result).to have_option "--storage"
+    expect(result).to have_option "--starting-from"
+    expect(result).to have_option "--now"
     expect(result).to have_option "--version"
 
     result = parse("cb upgrade start --cluster ")
@@ -829,6 +831,8 @@ Spectator.describe CB::Completion do
     expect(result).to have_option "--plan"
     expect(result).to have_option "--storage"
     expect(result).to have_option "--version"
+    expect(result).to have_option "--starting-from"
+    expect(result).to have_option "--now"
 
     result = parse("cb upgrade start --ha true ")
     expect(result).to have_option "--cluster"

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -502,6 +502,7 @@ Spectator.describe CB::Completion do
     expect(result).to have_option "info"
     expect(result).to have_option "set"
     expect(result).to have_option "cancel"
+    expect(result).to have_option "create"
 
     result = parse("cb maintenance info ")
     expect(result).to have_option "--cluster"
@@ -528,6 +529,11 @@ Spectator.describe CB::Completion do
 
     result = parse("cb maintenance set --cluster xx --unset ")
     result.should be_empty
+
+    result = parse "cb maintenance create"
+    expect(result).to have_option "--cluster"
+    expect(result).to have_option "--starting-from"
+    expect(result).to have_option "--now"
   end
 
   it "completes network" do

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -500,7 +500,7 @@ Spectator.describe CB::Completion do
 
     result = parse("cb maintenance ")
     expect(result).to have_option "info"
-    expect(result).to have_option "update"
+    expect(result).to have_option "set"
     expect(result).to have_option "cancel"
 
     result = parse("cb maintenance info ")
@@ -515,18 +515,18 @@ Spectator.describe CB::Completion do
     result = parse("cb maintenance cancel --cluster ")
     expect(result).to eq ["abc\tmy team/my cluster"]
 
-    result = parse "cb maintenance update "
+    result = parse "cb maintenance set "
     expect(result).to have_option "--cluster"
     expect(result).to have_option "--window-start"
     expect(result).to have_option "--unset"
 
-    result = parse("cb maintenance update --cluster ")
+    result = parse("cb maintenance set --cluster ")
     expect(result).to eq ["abc\tmy team/my cluster"]
 
-    result = parse("cb maintenance update --window-start ")
+    result = parse("cb maintenance set --window-start ")
     result.should be_empty
 
-    result = parse("cb maintenance update --cluster xx --unset ")
+    result = parse("cb maintenance set --cluster xx --unset ")
     result.should be_empty
   end
 

--- a/spec/cb/maintenance_spec.cr
+++ b/spec/cb/maintenance_spec.cr
@@ -20,14 +20,14 @@ Spectator.describe MaintenanceUpdate do
     expect(&.validate).to be_true
   end
 
-  it "reject if both unset and window-start are present" do
+  it "rejects if both unset and window-start are present" do
     action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
     action.window_start = 14
     action.unset = true
     expect(&.validate).to raise_error Program::Error, /Must use '--window-start' or '--unset'/
   end
 
-  it "reject invalid window-start " do
+  it "rejects invalid window-start " do
     action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
 
     action.window_start = -1

--- a/spec/cb/maintenance_spec.cr
+++ b/spec/cb/maintenance_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 include CB
 
-Spectator.describe MaintenanceUpdate do
+Spectator.describe MaintenanceWindowUpdate do
   subject(action) { described_class.new client: client, output: IO::Memory.new }
   let(client) { Client.new TEST_TOKEN }
 

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -112,6 +112,16 @@ module CB
       end
     end
 
+    macro time_setter(property)
+      property {{property}} : Time?
+
+      def {{property}}=(str : String)
+        self.{{property}} = Time.parse_rfc3339(str)
+      rescue Time::Format::Error
+        raise_arg_error "#{{{property.stringify}}} must be in rfc3339 format, e.g. 2022-01-01T00:00:00Z", str
+      end
+    end
+
     # Note: unlike the other macros, this one does not create a nilable boolean,
     # and instead creates one that defaults to false
     macro bool_setter(property)

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -40,7 +40,7 @@ abstract class CB::Upgrade < CB::APIAction
 end
 
 abstract class CB::UpgradeAction < CB::Upgrade
-  bool_setter ha
+  bool_setter? ha
   i32_setter postgres_version
   i32_setter storage
   time_setter starting_from

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -39,13 +39,15 @@ abstract class CB::Upgrade < CB::APIAction
   end
 end
 
-# Action to start cluster upgrade.
-class CB::UpgradeStart < CB::Upgrade
+abstract class CB::UpgradeAction < CB::Upgrade
   bool_setter ha
   i32_setter postgres_version
   i32_setter storage
   property plan : String?
+end
 
+# Action to start cluster upgrade.
+class CB::UpgradeStart < CB::UpgradeAction
   def run
     validate
 

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -75,6 +75,25 @@ class CB::UpgradeStart < CB::UpgradeAction
   end
 end
 
+# Action to create a cluster maintenance.
+class CB::UpgradeMaintenanceCreate < CB::UpgradeAction
+  def validate
+    super
+    raise Error.new "Maintenance can't change ha, postgres_version or storage." if !ha.nil? || postgres_version || storage || plan
+    true
+  end
+
+  def run
+    validate
+
+    c = client.get_cluster cluster_id
+    confirm_action("create maintenance", "cluster", c.name) unless confirmed
+
+    client.upgrade_cluster self
+    output.puts "  Maintenance created for Cluster #{c.id.colorize.t_id}."
+  end
+end
+
 # Action to cancel cluster upgrade.
 class CB::UpgradeCancel < CB::Upgrade
   def run

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -43,7 +43,23 @@ abstract class CB::UpgradeAction < CB::Upgrade
   bool_setter ha
   i32_setter postgres_version
   i32_setter storage
+  time_setter starting_from
+  bool_setter now
+
   property plan : String?
+
+  def validate
+    super
+
+    raise Error.new "Must use '--starting-from' or '--now' but not both." if starting_from && now
+
+    if now
+      starting_from = Time.utc
+    end
+
+    raise Error.new "'--starting-from' should be in less than a week" if (start = starting_from) && start > (Time.utc + Time::Span.new(days: 7))
+    true
+  end
 end
 
 # Action to start cluster upgrade.

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -337,20 +337,20 @@ class CB::Completion
     case @args[1]
     when "info"
       upgrade_status
-    when "update"
-      maintenance_update
+    when "set"
+      maintenance_window_update
     when "cancel"
       upgrade_cancel
     else
       [
         "info\tdetailed cluster maintenance information",
-        "update\tupdate cluster maintenance",
+        "set\tupdate the cluster default maintenance window",
         "cancel\tcancel a cluster maintenance",
       ]
     end
   end
 
-  def maintenance_update : Array(String)
+  def maintenance_window_update : Array(String)
     cluster = find_arg_value "--cluster"
 
     if last_arg?("--cluster")

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -900,6 +900,8 @@ class CB::Completion
     suggest << "--ha\thigh availability" unless has_full_flag? :ha
     suggest << "--plan\tplan" unless has_full_flag? :plan
     suggest << "--storage\tsize in GiB" unless has_full_flag? :storage
+    suggest << "--starting-from\tstarting time of upgrade. (RFC3339 format)" unless has_full_flag?(:starting_from) || has_full_flag?(:now)
+    suggest << "--now\tsize in GiB" unless has_full_flag?(:now) || has_full_flag?(:starting_from)
     suggest << "--version\tpostgres major version" unless has_full_flag? :version
     suggest
   end
@@ -970,6 +972,8 @@ class CB::Completion
     full << :authkey if has_full_flag? "--authkey"
     full << :window_start if has_full_flag? "--window-start"
     full << :unset if has_full_flag? "--unset"
+    full << :starting_from if has_full_flag? "--starting-from"
+    full << :now if has_full_flag? "--now"
     full << :no_header if has_full_flag? "--no-header"
     full
   end

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -341,11 +341,14 @@ class CB::Completion
       maintenance_window_update
     when "cancel"
       upgrade_cancel
+    when "create"
+      maintenance_create
     else
       [
         "info\tdisplay cluster maintenance information",
         "set\tupdate the cluster default maintenance window",
         "cancel\tcancel a cluster maintenance",
+        "create\tcreate a cluster maintenance",
       ]
     end
   end
@@ -365,6 +368,24 @@ class CB::Completion
     suggest << "--cluster\tcluster id" unless has_full_flag? :cluster
     suggest << "--window-start\tmaintenance window start (UTC)" unless has_full_flag?(:unset) || has_full_flag?(:window_start)
     suggest << "--unset\tUnset mainetnance window" unless has_full_flag?(:unset) || has_full_flag?(:window_start)
+    suggest
+  end
+
+  def maintenance_create : Array(String)
+    cluster = find_arg_value "--cluster"
+
+    if last_arg?("--cluster")
+      return cluster.nil? ? cluster_suggestions : [] of String
+    end
+
+    if last_arg?("--starting-from", "--now")
+      suggest_none
+    end
+
+    suggest = [] of String
+    suggest << "--cluster\tcluster id" unless has_full_flag? :cluster
+    suggest << "--starting-from\tStarting time to schedule a maintenance. (RFC3339 format)" unless has_full_flag?(:now) || has_full_flag?(:starting_from)
+    suggest << "--now\tStart a maintenance now" unless has_full_flag?(:now) || has_full_flag?(:starting_from)
     suggest
   end
 

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -343,7 +343,7 @@ class CB::Completion
       upgrade_cancel
     else
       [
-        "info\tdetailed cluster maintenance information",
+        "info\tdisplay cluster maintenance information",
         "set\tupdate the cluster default maintenance window",
         "cancel\tcancel a cluster maintenance",
       ]

--- a/src/cb/maintenance.cr
+++ b/src/cb/maintenance.cr
@@ -9,7 +9,7 @@ abstract class CB::MaintenanceAction < CB::APIAction
 end
 
 # Action to update cluster maintenance window
-class CB::MaintenanceUpdate < CB::MaintenanceAction
+class CB::MaintenanceWindowUpdate < CB::MaintenanceAction
   i32_setter window_start
   bool_setter unset
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -250,9 +250,9 @@ op = OptionParser.new do |parser|
   #
 
   parser.on("maintenance", "Manage cluster maintenance") do
-    parser.banner = "cb maintenance <info|set>"
+    parser.banner = "cb maintenance <info|set|cancel>"
 
-    parser.on("info", "Detailed cluster maintenance information") do
+    parser.on("info", "Display cluster maintenance information") do
       upgrade = set_action UpgradeStatus
       upgrade.maintenance_only = true
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -141,6 +141,8 @@ op = OptionParser.new do |parser|
 
   # Cluster Upgrade
   parser.on("upgrade", "Manage a cluster upgrades") do
+    parser.banner = "cb upgrade <start|status|cancel>"
+
     parser.on("start", "Start a cluster upgrade") do
       upgrade = set_action UpgradeStart
       parser.banner = "cb upgrade start <--cluster>"
@@ -152,9 +154,23 @@ op = OptionParser.new do |parser|
       parser.on("-s GiB", "--storage GiB", "Storage size") { |arg| upgrade.storage = arg }
       parser.on("--starting-from START", "Starting time of upgrade. (RFC3339 format)") { |arg| upgrade.starting_from = arg }
       parser.on("--now", "Start the upgrade now") { |_| upgrade.now = true }
-      parser.on("--confirm", "Confirm cluster restart") do
+      parser.on("--confirm", "Confirm cluster upgrade") do
         upgrade.confirmed = true
       end
+
+      parser.examples = <<-EXAMPLES
+        Upgrade to high availability.
+        $ cb upgrade start --cluster <ID> --ha true
+
+        Upgrade storage and failover during the cluster maintenance window.
+        $ cb upgrade start --cluster <ID> --storage 200
+
+        Upgrade plan and failover as soon as possible.
+        $ cb upgrade start --cluster <ID> --plan memory-128 --now
+
+        Upgrade postgres major version and storage and failover at the given time.
+        $ cb upgrade start --cluster <ID> --version 15 --storage 800 --starting-from 2022-01-01T00:00:00Z
+      EXAMPLES
     end
 
     parser.on("cancel", "Cancel a cluster upgrade") do

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -250,7 +250,7 @@ op = OptionParser.new do |parser|
   #
 
   parser.on("maintenance", "Manage cluster maintenance") do
-    parser.banner = "cb maintenance <info|update>"
+    parser.banner = "cb maintenance <info|set>"
 
     parser.on("info", "Detailed cluster maintenance information") do
       upgrade = set_action UpgradeStatus
@@ -267,9 +267,9 @@ op = OptionParser.new do |parser|
       parser.on("--cluster ID", "Choose cluster") { |arg| upgrade.cluster_id = arg }
     end
 
-    parser.on("update", "Update cluster maintenance") do
-      update = set_action MaintenanceUpdate
-      parser.banner = "cb maintenance update <--cluster> [--window-start] [--unset]"
+    parser.on("set", "Update the cluster default maintenance window") do
+      update = set_action MaintenanceWindowUpdate
+      parser.banner = "cb maintenance set <--cluster> [--window-start] [--unset]"
       parser.on("--cluster ID", "Choose cluster") { |arg| update.cluster_id = arg }
       parser.on("--window-start START", "Hour maintenance window start (UTC)") { |arg| update.window_start = arg }
       parser.on("--unset", "Unset mainetnance window") { |_| update.unset = true }

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -276,6 +276,26 @@ op = OptionParser.new do |parser|
       parser.on("--window-start START", "Hour maintenance window start (UTC)") { |arg| update.window_start = arg }
       parser.on("--unset", "Unset mainetnance window") { |_| update.unset = true }
     end
+
+    parser.on("create", "Create a cluster maintenance") do
+      create = set_action UpgradeMaintenanceCreate
+      parser.banner = "cb maintenance create <--cluster> [--starting-from] [--now]"
+      parser.on("--cluster ID", "Choose cluster") { |arg| create.cluster_id = arg }
+      parser.on("--starting-from START", "Starting time to create a maintenance. (RFC3339 format)") { |arg| create.starting_from = arg }
+      parser.on("--now", "Start a maintenance now") { |_| create.now = true }
+      parser.on("--confirm", "Confirm maintenance creation.") { |_| create.confirmed = true }
+
+      parser.examples = <<-EXAMPLES
+        Create a maintenance that will failover during the cluster maintenance window
+        $ cb maintenance create --cluster <ID>
+
+        Create a maintenance that will failover as soon as possible
+        $ cb maintenance create --cluster <ID> --now
+
+        Create a maintenance that will failover starting from a given time
+        $ cb maintenance create --cluster <ID> --starting-from 2022-01-01T00:00:00Z
+      EXAMPLES
+    end
   end
 
   #

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -150,6 +150,8 @@ op = OptionParser.new do |parser|
       parser.on("-v VERSION", "--version VERSION", "Postgres major version") { |arg| upgrade.postgres_version = arg }
       parser.on("--plan NAME", "Plan (server vCPU+memory)") { |arg| upgrade.plan = arg }
       parser.on("-s GiB", "--storage GiB", "Storage size") { |arg| upgrade.storage = arg }
+      parser.on("--starting-from START", "Starting time of upgrade. (RFC3339 format)") { |arg| upgrade.starting_from = arg }
+      parser.on("--now", "Start the upgrade now") { |_| upgrade.now = true }
       parser.on("--confirm", "Confirm cluster restart") do
         upgrade.confirmed = true
       end

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -119,6 +119,7 @@ module CB
         plan_id:             uc.plan,
         postgres_version_id: uc.postgres_version,
         storage:             uc.storage,
+        starting_from:       uc.starting_from,
       }
       Array(Operation).from_json resp.body, root: "operations"
     end


### PR DESCRIPTION
From the changelog change:
- `cb maintenance` command now supports `cancel` and `create`
- `cb upgrade start` command accepts `--starting-from` and `--now` options that
   specify upgrade failower window. Default to cluster maintenance window.
- `cb upgrade start` don't change `ha` by default.

completes BR-1383