### PR TITLE
Display failover window on operation

### DIFF
--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -65,7 +65,7 @@ Spectator.describe CB::UpgradeStatus do
 
     expect(client).to receive(:get_cluster).and_return(cluster)
     expect(client).to receive(:get_team).and_return(team)
-    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("ha_change", "fake")])
+    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("ha_change", "fake", nil)])
 
     action.call
 
@@ -78,13 +78,31 @@ Spectator.describe CB::UpgradeStatus do
     expect(&.output.to_s).to eq expected
   end
 
+  it "#run display failover windown starting if there is one" do
+    action.cluster_id = cluster.id
+
+    expect(client).to receive(:get_cluster).and_return(cluster)
+    expect(client).to receive(:get_team).and_return(team)
+    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("resize", "fake", "2022-01-01T00:00:00Z")])
+
+    action.call
+
+    expected = <<-EXPECTED
+  #{team.name}/#{cluster.name}
+    maintenance window: no window set. Default to: 00:00-23:59
+                resize: fake (Starting from: 2022-01-01T00:00:00Z)\n
+  EXPECTED
+
+    expect(&.output.to_s).to eq expected
+  end
+
   it "#run filter ha operation if told so" do
     action.cluster_id = cluster.id
     action.maintenance_only = true
 
     expect(client).to receive(:get_cluster).and_return(cluster)
     expect(client).to receive(:get_team).and_return(team)
-    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("ha_change", "fake")])
+    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("ha_change", "fake", nil)])
 
     action.call
 

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -77,7 +77,7 @@ class CB::UpgradeStatus < CB::Upgrade
     end
 
     operations.each do |op|
-      details[op.flavor] = op.state
+      details[op.flavor] = op.one_line_state_display
     end
 
     if operations.empty?

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -6,7 +6,12 @@ module CB
       replicas : Array(Cluster)?
 
     # Upgrade operation.
-    jrecord Operation, flavor : String, state : String
+    jrecord Operation, flavor : String, state : String, starting_from : String? do
+      def one_line_state_display
+        from = " (Starting from: #{starting_from})" if starting_from
+        "#{state}#{from}"
+      end
+    end
 
     def get_clusters
       get_clusters(get_teams)


### PR DESCRIPTION
An operation either waits its custom failover window denoted by the optional field `starting_from` or the cluster maintenance window.

This display the `starting_from` on each operation if present.