### PR TITLE
Add `cb config-param` command.

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -5,3 +5,11 @@ Metrics/CyclomaticComplexity:
   - src/cb/completion.cr
   Enabled: true
   Severity: Convention
+
+Layout/TrailingWhitespace:
+  Description: Disallows trailing whitespace.
+  Excluded:
+  # exclude spec files as some expected output might contain trailing
+  # whitespaces.
+  - spec/*/***
+  Enabled: true

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ clean:
 .PHONY: spec
 spec: libs deps $(SOURCES)
 	$(CRYSTAL_BIN) tool format --check
+	$(CURDIR)/bin/ameba
 	@if [ "$(TARGET_OS)" == "darwin" ]; then \
 		LIBRARY_PATH=$(STATIC_LIBS_DIR) $(CRYSTAL_BIN) spec -Dmt_no_expectations --error-trace; \
 	else \

--- a/spec/cb/config_param_spec.cr
+++ b/spec/cb/config_param_spec.cr
@@ -1,0 +1,201 @@
+require "../spec_helper"
+
+Spectator.describe ConfigurationParameterGet do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  let(client) { Client.new TEST_TOKEN }
+  let(cluster) { Factory.cluster }
+
+  mock_client
+
+  describe "#validate" do
+    it "validates that required arguments are present" do
+      expect(&.validate).to raise_error Program::Error, /Missing required argument/
+
+      action.cluster_id = cluster.id
+
+      expect(&.validate).to be_true
+    end
+  end
+
+  describe "#call" do
+    before_each {
+      action.cluster_id = cluster.id
+    }
+
+    it "gets by name" do
+      action.name = "postgres:max_connections"
+
+      expect(client).to receive(:get_configuration_parameter).and_return(Factory.configuration_parameter)
+
+      action.call
+
+      expected = <<-EXPECTED
+        Component   Name              Value  
+      ───────────────────────────────────────
+        postgres    max_connections   100    \n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+
+    it "outputs default format" do
+      expect(client).to receive(:get_all_configuration_parameters).and_return([Factory.configuration_parameter, Factory.configuration_parameter])
+
+      action.call
+
+      expected = <<-EXPECTED
+        Component   Name              Value  
+      ───────────────────────────────────────
+        postgres    max_connections   100    
+        postgres    max_connections   100    \n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+
+    it "outputs json format" do
+      action.format = Format::JSON
+
+      expect(client).to receive(:get_all_configuration_parameters).and_return([Factory.configuration_parameter])
+
+      action.call
+
+      expected = <<-EXPECTED
+      {
+        "parameters": [
+          {
+            "component": "postgres",
+            "name": "postgres:max_connections",
+            "parameter_name": "max_connections",
+            "value": "100"
+          }
+        ]
+      }\n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+  end
+end
+
+Spectator.describe ConfigurationParameterSet do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  let(client) { Client.new TEST_TOKEN }
+  let(cluster) { Factory.cluster }
+
+  mock_client
+
+  describe "#call" do
+    before_each {
+      action.args = ["postgres:max_connections=100"]
+      action.cluster_id = cluster.id
+    }
+
+    it "outputs default" do
+      expect(client).to receive(:set_configuration_parameters).and_return [Factory.configuration_parameter]
+
+      action.call
+
+      expected = <<-EXPECTED
+        Component   Name              Value  
+      ───────────────────────────────────────
+        postgres    max_connections   100    \n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+
+    it "outputs json format" do
+      action.format = Format::JSON
+
+      expect(client).to receive(:set_configuration_parameters).and_return([Factory.configuration_parameter])
+
+      action.call
+
+      expected = <<-EXPECTED
+        {
+          "parameters": [
+            {
+              "component": "postgres",
+              "name": "postgres:max_connections",
+              "parameter_name": "max_connections",
+              "value": "100"
+            }
+          ]
+        }\n
+        EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+  end
+end
+
+Spectator.describe ConfigurationParameterReset do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  let(client) { Client.new TEST_TOKEN }
+  let(cluster) { Factory.cluster }
+
+  mock_client
+
+  describe "#call" do
+    before_each {
+      action.cluster_id = cluster.id
+    }
+
+    it "resets single parameters" do
+      action.name = "postgres:max_connections"
+
+      expect(client).to receive(:reset_configuration_parameter).and_return Factory.configuration_parameter
+
+      action.call
+
+      expected = <<-EXPECTED
+        Component   Name              Value  
+      ───────────────────────────────────────
+        postgres    max_connections   100    \n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+
+    it "outputs default" do
+      expect(client).to receive(:reset_all_configuration_parameters).and_return [Factory.configuration_parameter]
+
+      action.call
+
+      expected = <<-EXPECTED
+        Component   Name              Value  
+      ───────────────────────────────────────
+        postgres    max_connections   100    \n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+
+    it "outputs json format" do
+      action.format = Format::JSON
+
+      expect(client).to receive(:reset_all_configuration_parameters).and_return([Factory.configuration_parameter])
+
+      action.call
+
+      expected = <<-EXPECTED
+        {
+          "parameters": [
+            {
+              "component": "postgres",
+              "name": "postgres:max_connections",
+              "parameter_name": "max_connections",
+              "value": "100"
+            }
+          ]
+        }\n
+        EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+  end
+end

--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -70,7 +70,7 @@ Spectator.describe RoleList do
   it "outputs json" do
     action.output = IO::Memory.new
     action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
-    action.format = CB::RoleList::Format::JSON
+    action.format = CB::Format::JSON
 
     expect(client).to receive(:get_cluster).and_return cluster
     expect(client).to receive(:get_team).and_return team

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -80,6 +80,17 @@ module Factory
     CB::Client::ClusterDetail.new **params
   end
 
+  def configuration_parameter(**params)
+    params = {
+      component:      "postgres",
+      name:           "postgres:max_connections",
+      parameter_name: "max_connections",
+      value:          "100",
+    }.merge(params)
+
+    CB::Client::ConfigurationParameter.new **params
+  end
+
   def user_role(**params)
     params = {
       account_email: "user@example.com",

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -39,6 +39,14 @@ module CB
       end
     end
 
+    macro format_setter(property)
+      property {{property}} : Format = Format::Default
+
+      def {{property}}=(str : String)
+        @{{property}} = Format.parse(str)
+      end
+    end
+
     macro role_setter(property)
       property {{property}} : Role = Role.new
 

--- a/src/cb/config_param.cr
+++ b/src/cb/config_param.cr
@@ -1,0 +1,127 @@
+require "./action"
+
+module CB
+  # API action for configuration parameters.
+  #
+  # All configuration parameter actions must inherit this action.
+  abstract class ConfigurationParameterAction < APIAction
+    # The cluster ID.
+    cluster_identifier_setter cluster_id
+
+    # The output format. The default format is table format.
+    format_setter format
+
+    # Flag to indicate whether the output should include a header. This only
+    # has an effect when the output format is a table.
+    property with_header : Bool = true
+
+    # Result of api calls.
+    property parameters : Array(Client::ConfigurationParameter) = [] of Client::ConfigurationParameter
+
+    def validate
+      check_required_args do |missing|
+        missing << "cluster" if @cluster_id.empty?
+      end
+    end
+
+    def run
+      validate
+    end
+
+    protected def output_default
+      table = Table::TableBuilder.new(border: :none) do
+        columns do
+          add "Component"
+          add "Name"
+          add "Value"
+        end
+
+        header if with_header
+
+        @parameters.each do |p|
+          row [p.component, p.parameter_name, p.value]
+        end
+      end
+
+      output << table.render << '\n'
+    end
+
+    protected def output_json
+      output << {
+        "parameters": @parameters,
+      }.to_pretty_json << '\n'
+    end
+  end
+
+  # Action for getting configuration parameters.
+  class ConfigurationParameterGet < ConfigurationParameterAction
+    # The name of the configuration parameter to get.
+    property name : String? = nil
+
+    def run
+      super
+
+      if @name
+        @parameters = [client.get_configuration_parameter(cluster_id[:cluster], @name.as(String))]
+      else
+        @parameters = client.get_all_configuration_parameters cluster_id[:cluster]
+      end
+
+      case @format
+      when Format::Default
+        output_default
+      when Format::JSON
+        output_json
+      end
+    end
+  end
+
+  # Action for setting configuration parameters.
+  class ConfigurationParameterSet < ConfigurationParameterAction
+    # The list of configuration parameters to set and their values.
+    property args : Array(String) = [] of String
+
+    def run
+      super
+
+      parameters : Array(Hash(String, String)) = [] of Hash(String, String)
+
+      @args.each do |arg|
+        parts = arg.split('=')
+        parameters << {"name" => parts[0], "value" => parts[1]}
+      end
+
+      @parameters = client.set_configuration_parameters(cluster_id[:cluster], parameters)
+
+      case @format
+      when Format::Default
+        output_default
+      when Format::JSON
+        output_json
+      end
+    end
+  end
+
+  # Action for resetting configuration parameters.
+  class ConfigurationParameterReset < ConfigurationParameterAction
+    # The name of the parameter to reset.
+    property name : String? = nil
+
+    def run
+      super
+
+      if @name
+        @parameters = [client.reset_configuration_parameter(cluster_id[:cluster], @name.as(String))]
+      else
+        @parameters = client.reset_all_configuration_parameters cluster_id[:cluster]
+      end
+
+      case @format
+      when Format::Default
+        output_default
+      when Format::JSON
+        output_json
+      end
+    end
+  end
+end

--- a/src/cb/format.cr
+++ b/src/cb/format.cr
@@ -1,0 +1,7 @@
+module CB
+  enum Format
+    Default
+    JSON
+    Table
+  end
+end

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -22,12 +22,7 @@ class CB::RoleCreate < CB::RoleAction
 end
 
 class CB::RoleList < CB::RoleAction
-  enum Format
-    Default
-    JSON
-  end
-
-  property format : Format = Format::Default
+  format_setter format
 
   private property cluster : Client::ClusterDetail?
 
@@ -57,9 +52,9 @@ class CB::RoleList < CB::RoleAction
     end
 
     case @format
-    when Format::JSON
+    when CB::Format::JSON
       output_json
-    when Format::Default
+    when CB::Format::Default
       output_default
     end
   end

--- a/src/cb/table.cr
+++ b/src/cb/table.cr
@@ -1,0 +1,32 @@
+require "tallboy"
+
+module CB::Table
+  class TableBuilder < Tallboy::TableBuilder
+    def render(io = IO::Memory.new)
+      DefaultRenderer.new(self.build).render(io)
+    end
+  end
+
+  class DefaultRenderer < Tallboy::Renderer
+    @@border_style = {
+      "corner_top_left"     => "",
+      "corner_top_right"    => "",
+      "corner_bottom_right" => "",
+      "corner_bottom_left"  => "",
+      "edge_top"            => "─",
+      "edge_right"          => "",
+      "edge_bottom"         => "",
+      "edge_left"           => "",
+      "tee_top"             => "", # no effect
+      "tee_right"           => "─",
+      "tee_bottom"          => "",
+      "tee_left"            => "─",
+      "divider_vertical"    => "", # nope
+      "divider_horizontal"  => "", # no effect
+      "joint_horizontal"    => "", # no effect
+      "joint_vertical"      => "",
+      "cross"               => "─",
+      "content"             => "",
+    }
+  end
+end

--- a/src/cb/token.cr
+++ b/src/cb/token.cr
@@ -5,24 +5,15 @@ require "./cacheable"
 # potentially namespace actions under `CB::Action` or something. Something
 # perhaps worth considering.
 class CB::TokenAction < CB::Action
-  enum Format
-    Default
-    Header
-  end
-
   property token : Token
-  property format : Format = Format::Default
+  bool_setter? with_header
 
   def initialize(@token, @input, @output)
   end
 
   def run
-    case @format
-    when Format::Header
-      output << "Authorization: Bearer #{token.token}"
-    when Format::Default
-      output << token.token
-    end
+    output << "Authorization: Bearer " if with_header
+    output << token.token
   end
 end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -131,6 +131,73 @@ op = OptionParser.new do |parser|
     parser.on("--at TIME", "Recovery point-in-time in RFC3339 (default: now)") { |arg| create.at = arg }
   end
 
+  #
+  # Custom Configuration Parameter Management
+  #
+
+  parser.on("config-param", "Manage custom configuration parameters") do
+    parser.banner = "cb config-param <command>"
+
+    # TODO (abrightwell): would be really cool to implement this kind of
+    # support.
+    #
+    # parser.on("edit", "interactively edit config values") do
+    # parser.on("--cluster ID", "Choose cluster")
+    # end
+
+    parser.on("get", "display one or more configuration parameters for a cluster") do
+      parser.banner = "cb config-param get <--cluster> [--name]"
+
+      get = set_action ConfigurationParameterGet
+      parser.on("--cluster ID", "Choose cluster") { |arg| get.cluster_id = arg }
+      parser.on("--name NAME", "Confguration parameter name") { |arg| get.name = arg }
+
+      parser.examples = <<-EXAMPLES
+        Get a single configuration parameter:
+        $ cb config-params get --cluster <ID> --name postgres:max_connections
+
+        Get all configuration parameters:
+        $ cb config-params get --cluster <ID>
+      EXAMPLES
+    end
+
+    parser.on("set", "set one or more configuration parameter values") do
+      parser.banner = "cb config-param set <--cluster> <NAME=VALUE> [...]"
+
+      set = set_action ConfigurationParameterSet
+      parser.on("--cluster ID", "Choose cluster") { |arg| set.cluster_id = arg }
+
+      parser.unknown_args { |args| set.args = args }
+
+      parser.examples = <<-EXAMPLES
+        Set a single configuration parameter:
+        $ cb config-params set --cluster <ID> postgres:max_connections=100
+
+        Set multiple configuration parameters:
+        $ cb config-params set --cluster <ID> postgres:max_connections=100 postgres:hot_standby=off
+      EXAMPLES
+    end
+
+    parser.on("reset", "reset one or more configuration parameter values to default") do
+      parser.banner = "cb config-params reset <--cluster> <NAME [...]>"
+
+      reset = set_action ConfigurationParameterReset
+      parser.on("--cluster ID", "Choose cluster") { |arg| reset.cluster_id = arg }
+      # parser.on("--confirm", "Confirm configuration revert") { reset.confirmed = true }
+
+      parser.examples = <<-EXAMPLES
+        Revert a single configuration parameter:
+        $ cb config-param revert --cluster <ID> postgres:max_connections
+
+        Revert multiple configuration parameters:
+        $ cb config-param revert --cluster <ID> postgres:max_connections postgres:hot_standby
+
+        Revert all configuration parameters:
+        $ cb config-param revert --cluster <ID> --all
+      EXAMPLES
+    end
+  end
+
   # Cluster Upgrade
   parser.on("upgrade", "Manage a cluster upgrades") do
     parser.on("start", "Start a cluster upgrade") do

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -313,7 +313,7 @@ op = OptionParser.new do |parser|
       list = set_action RoleList
       parser.banner = "cb role list <--cluster>"
       parser.on("--cluster ID", "Choose cluster") { |arg| list.cluster_id = arg }
-      parser.on("--format FORMAT", "Choose output format") { |arg| list.format = CB::RoleList::Format.parse(arg) }
+      parser.on("--format FORMAT", "Choose output format") { |arg| list.format = arg }
     end
 
     parser.on("update", "Update a cluster role") do
@@ -475,7 +475,7 @@ op = OptionParser.new do |parser|
     parser.banner = "cb token [-H]"
     token = action = CB::TokenAction.new PROG.token, PROG.input, PROG.output
 
-    parser.on("-H", "Authorization header format") { token.format = CB::TokenAction::Format::Header }
+    parser.on("-H", "Authorization header format") { token.with_header = true }
   end
 
   parser.on("version", "Show the version") do

--- a/src/client/config_param.cr
+++ b/src/client/config_param.cr
@@ -1,0 +1,46 @@
+require "./client"
+
+module CB
+  class Client
+    jrecord ConfigurationParameter,
+      component : String? = nil,
+      name : String = "",
+      parameter_name : String? = nil,
+      value : String = "" do
+      @[JSON::Field(key: "parameter_name", emit_null: false)]
+      def to_s(io : IO)
+        io << name.colorize.t_name << '=' << value
+      end
+    end
+
+    # Get configuration parameter value
+    def get_configuration_parameter(id : Identifier, name : String)
+      resp = get "/clusters/#{id}/configuration-parameters/#{name}"
+      ConfigurationParameter.from_json resp.body
+    end
+
+    # Get configuration parameter values.
+    def get_all_configuration_parameters(id : Identifier)
+      resp = get "/clusters/#{id}/configuration-parameters"
+      Array(ConfigurationParameter).from_json resp.body, root: "parameters"
+    end
+
+    # Set configuration parameter values.
+    def set_configuration_parameters(id, parameters)
+      resp = put "/clusters/#{id}/configuration-parameters", {"parameters": parameters}
+      Array(ConfigurationParameter).from_json resp.body, root: "parameters"
+    end
+
+    # Reset configuration parameter value.
+    def reset_configuration_parameter(id, name)
+      resp = delete "/clusters/#{id}/configuration-parameters/#{name}"
+      ConfigurationParameter.from_json resp.body
+    end
+
+    # Reset configuration parameters values.
+    def reset_all_configuration_parameters(id)
+      resp = delete "/clusters/#{id}/configuration-parameters"
+      Array(ConfigurationParameter).from_json resp.body, root: "parameters"
+    end
+  end
+end

--- a/src/ext/option_parser.cr
+++ b/src/ext/option_parser.cr
@@ -39,7 +39,7 @@ class OptionParser
       io << '\n'
     end
 
-    unless examples.nil?
+    if examples
       io << '\n' << "Examples".colorize.bold << ":\n"
       io << examples << '\n'
     end


### PR DESCRIPTION
**WIP: Until API supports.**

Add `cb config-param` command.

Add `cb config-param` command to manage custom cluster configuration
parameters.

Supports the following subcommands:

`get` - get configuration parameter values.
`set` - set configuration parameter values.
`reset` - reset configuration parameter values.

Examples:
```
$ cb config-param get
Component   Name              Value
───────────────────────────────────────
postgres    max_connections   100
```

```
$ cb config-param set postgres:max_connections=200
 Component   Name              Value
───────────────────────────────────────
 postgres    max_connections   200
```

```
$ cb config-param reset --name postgres:max_connections
 Component   Name              Value
───────────────────────────────────────
 postgres    max_connections   100
```

Completes BR-973