### PR TITLE
Add `Format` enum and custom table renderer.

### DIFF
--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -70,7 +70,7 @@ Spectator.describe RoleList do
   it "outputs json" do
     action.output = IO::Memory.new
     action.cluster_id = "pkdpq6yynjgjbps4otxd7il2u4"
-    action.format = CB::RoleList::Format::JSON
+    action.format = CB::Format::JSON
 
     expect(client).to receive(:get_cluster).and_return cluster
     expect(client).to receive(:get_team).and_return team

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -39,6 +39,14 @@ module CB
       end
     end
 
+    macro format_setter(property)
+      property {{property}} : Format = Format::Default
+
+      def {{property}}=(str : String)
+        @{{property}} = Format.parse(str)
+      end
+    end
+
     macro role_setter(property)
       property {{property}} : Role = Role.new
 

--- a/src/cb/format.cr
+++ b/src/cb/format.cr
@@ -1,0 +1,7 @@
+module CB
+  enum Format
+    Default
+    JSON
+    Table
+  end
+end

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -22,12 +22,7 @@ class CB::RoleCreate < CB::RoleAction
 end
 
 class CB::RoleList < CB::RoleAction
-  enum Format
-    Default
-    JSON
-  end
-
-  property format : Format = Format::Default
+  format_setter format
 
   private property cluster : Client::ClusterDetail?
 
@@ -57,9 +52,9 @@ class CB::RoleList < CB::RoleAction
     end
 
     case @format
-    when Format::JSON
+    when CB::Format::JSON
       output_json
-    when Format::Default
+    when CB::Format::Default, CB::Format::Table
       output_default
     end
   end

--- a/src/cb/table.cr
+++ b/src/cb/table.cr
@@ -1,0 +1,40 @@
+require "tallboy"
+
+module CB::Table
+  class TableBuilder < Tallboy::TableBuilder
+    def header
+      header(@columns.map(&.name.colorize.bold.underline))
+    end
+
+    def header(arr : Array)
+      row(arr, :none)
+    end
+
+    def render(io = IO::Memory.new)
+      DefaultRenderer.new(self.build).render(io)
+    end
+  end
+
+  class DefaultRenderer < Tallboy::Renderer
+    @@border_style = {
+      "corner_top_left"     => "",
+      "corner_top_right"    => "",
+      "corner_bottom_right" => "",
+      "corner_bottom_left"  => "",
+      "edge_top"            => "",
+      "edge_right"          => "",
+      "edge_bottom"         => "",
+      "edge_left"           => "",
+      "tee_top"             => "",
+      "tee_right"           => "",
+      "tee_bottom"          => "",
+      "tee_left"            => "",
+      "divider_vertical"    => "",
+      "divider_horizontal"  => "",
+      "joint_horizontal"    => "",
+      "joint_vertical"      => "",
+      "cross"               => "",
+      "content"             => "",
+    }
+  end
+end

--- a/src/cb/token.cr
+++ b/src/cb/token.cr
@@ -5,24 +5,15 @@ require "./cacheable"
 # potentially namespace actions under `CB::Action` or something. Something
 # perhaps worth considering.
 class CB::TokenAction < CB::Action
-  enum Format
-    Default
-    Header
-  end
-
   property token : Token
-  property format : Format = Format::Default
+  bool_setter? with_header
 
   def initialize(@token, @input, @output)
   end
 
   def run
-    case @format
-    when Format::Header
-      output << "Authorization: Bearer #{token.token}"
-    when Format::Default
-      output << token.token
-    end
+    output << "Authorization: Bearer " if with_header
+    output << token.token
   end
 end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -313,7 +313,7 @@ op = OptionParser.new do |parser|
       list = set_action RoleList
       parser.banner = "cb role list <--cluster>"
       parser.on("--cluster ID", "Choose cluster") { |arg| list.cluster_id = arg }
-      parser.on("--format FORMAT", "Choose output format") { |arg| list.format = CB::RoleList::Format.parse(arg) }
+      parser.on("--format FORMAT", "Choose output format (default: table)") { |arg| list.format = arg }
     end
 
     parser.on("update", "Update a cluster role") do
@@ -475,7 +475,7 @@ op = OptionParser.new do |parser|
     parser.banner = "cb token [-H]"
     token = action = CB::TokenAction.new PROG.token, PROG.input, PROG.output
 
-    parser.on("-H", "Authorization header format") { token.format = CB::TokenAction::Format::Header }
+    parser.on("-H", "Authorization header format") { token.with_header = true }
   end
 
   parser.on("version", "Show the version") do


### PR DESCRIPTION
These are the same changes that are introduced in #83.  However, I'm separating them out so that they can start to be incorporated in other actions/commands since that PR is still a WIP/Draft.

* Add `Format` enum for output formats.

Previously, we had started to define this at the action level as it was
more about experimenting with it. But now it seems like something we
should likely just pull up to the top level so that all actions can
benefit from it at some point.

* Add custom table renderer for Tallboy. 