### PR TITLE
Refactor `role list` table format.

### DIFF
--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -546,16 +546,23 @@ Spectator.describe CB::Completion do
 
     # cb role list
     result = parse("cb role list ")
-    result.should have_option "--cluster"
+    expect(result).to have_option "--cluster"
 
     result = parse("cb role list --cluster ")
-    result.should eq ["abc\tmy team/my cluster"]
+    expect(result).to eq ["abc\tmy team/my cluster"]
 
     result = parse("cb role list --cluster abc ")
-    result.should have_option "--format"
+    expect(result).to have_option "--format"
+    expect(result).to have_option "--no-header"
 
     result = parse("cb role list --cluster abc --format ")
-    result.should eq ["default", "json"]
+    expect(result).to eq ["table", "json"]
+
+    result = parse("cb role list --cluster abc --format table ")
+    expect(result).to have_option "--no-header"
+
+    result = parse("cb role list --cluster abc --format table --no-header ")
+    expect(result).to eq [] of String
 
     # cb role update
     result = parse("cb role update ")

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -420,11 +420,12 @@ class CB::Completion
     end
 
     if last_arg?("--format")
-      return ["default", "json"]
+      return ["table", "json"]
     end
 
     suggest = [] of String
     suggest << "--format\toutput format" unless has_full_flag? :format
+    suggest << "--no-header\tomit table header" unless has_full_flag? :no_header
     suggest
   end
 
@@ -917,6 +918,7 @@ class CB::Completion
     full << :authkey if has_full_flag? "--authkey"
     full << :window_start if has_full_flag? "--window-start"
     full << :unset if has_full_flag? "--unset"
+    full << :no_header if has_full_flag? "--no-header"
     full
   end
 

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -1,5 +1,5 @@
 require "./action"
-require "tallboy"
+require "./table"
 
 abstract class CB::RoleAction < CB::APIAction
   eid_setter cluster_id
@@ -23,6 +23,8 @@ end
 
 class CB::RoleList < CB::RoleAction
   format_setter format
+
+  bool_setter? no_header
 
   private property cluster : Client::ClusterDetail?
 
@@ -60,24 +62,20 @@ class CB::RoleList < CB::RoleAction
   end
 
   def output_default
-    table = Tallboy.table do
+    table = Table::TableBuilder.new(border: :none) do
       columns do
         add "Role"
         add "Account"
       end
 
-      header <<-GENERAL_HEADER
-        Cluster: #{@cluster.try &.name}
-        Team:    #{@team.try &.name}
-        GENERAL_HEADER
-
-      header
+      header unless no_header
 
       @roles.each do |role|
         row [role["role"], role["account"]]
       end
     end
-    output << table.render(:ascii) << '\n'
+
+    output << table.render << '\n'
   end
 
   def output_json

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -314,6 +314,18 @@ op = OptionParser.new do |parser|
       parser.banner = "cb role list <--cluster>"
       parser.on("--cluster ID", "Choose cluster") { |arg| list.cluster_id = arg }
       parser.on("--format FORMAT", "Choose output format (default: table)") { |arg| list.format = arg }
+      parser.on("--no-header", "Do not display table header") { |arg| list.no_header = true }
+
+      parser.examples = <<-EXAMPLES
+        Get roles for a cluster. Output: table
+        $ cb role list --cluster <ID>
+
+        Get roles for a cluster. Output: table without header
+        $ cb role list --cluster <ID> --no-header
+
+        Get roles for a cluster. Output: json
+        $ cb role list --cluster <ID> --format=json
+      EXAMPLES
     end
 
     parser.on("update", "Update a cluster role") do


### PR DESCRIPTION
Refactor `role list` to use custom renderer. As well, we adding a `--no-header` flag to the command to omit the table header from the output if desired.

Based on #85 until merged.