### PR TITLE
Add `Format::List`.

### DIFF
--- a/spec/cb/team_spec.cr
+++ b/spec/cb/team_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+
+Spectator.describe TeamInfo do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  mock_client
+
+  let(team) { Factory.team }
+
+  describe "#call" do
+    it "outputs as list" do
+      action.team_id = team.id
+
+      expect(client).to receive(:get_team).and_return team
+
+      action.call
+
+      expected = <<-EXPECTED
+        ID:              l2gnkxjv3beifk6abkraerv7de  
+        Name:            Test Team                   
+        Role:            Admin                       
+        Billing Email:   test@example.com            
+        Enforce SSO:     disabled                    \n
+      EXPECTED
+
+      expect(&.output.to_s).to eq expected
+    end
+  end
+end

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -119,8 +119,8 @@ module Factory
       id:            "l2gnkxjv3beifk6abkraerv7de",
       name:          "Test Team",
       is_personal:   false,
-      role:          nil,
-      billing_email: nil,
+      role:          "admin",
+      billing_email: "test@example.com",
       enforce_sso:   nil,
     }.merge(params)
 

--- a/src/cb/format.cr
+++ b/src/cb/format.cr
@@ -2,6 +2,7 @@ module CB
   enum Format
     Default
     JSON
+    List
     Table
   end
 end

--- a/src/cb/team.cr
+++ b/src/cb/team.cr
@@ -3,14 +3,18 @@ require "./action"
 abstract class CB::TeamAction < CB::APIAction
   eid_setter team_id
 
-  private def team_details(t : CB::Client::Team) : String
-    String.build do |str|
-      str << "ID:           \t" << t.id.colorize.t_id << "\n"
-      str << "Name:         \t" << t.name.colorize.t_name << "\n"
-      str << "Role:         \t" << t.role.to_s.titleize << "\n"
-      str << "Billing Email:\t" << t.billing_email << "\n"
-      str << "Enforce SSO:  \t" << (t.enforce_sso.nil? ? "disabled" : t.enforce_sso)
+  format_setter format
+
+  private def output_team_details(t : CB::Client::Team)
+    table = Table::TableBuilder.new(border: :none) do
+      row ["ID:", t.id.colorize.t_id]
+      row ["Name:", t.name.colorize.t_name]
+      row ["Role:", t.role.to_s.titleize]
+      row ["Billing Email:", t.billing_email]
+      row ["Enforce SSO:", (t.enforce_sso.nil? ? "disabled" : t.enforce_sso)]
     end
+
+    output << table.render << '\n'
   end
 end
 
@@ -43,7 +47,11 @@ end
 class CB::TeamInfo < CB::TeamAction
   def run
     team = client.get_team team_id
-    output << team_details(team) << "\n"
+
+    case @format
+    when Format::Default, Format::List
+      output_team_details(team)
+    end
   end
 end
 
@@ -80,7 +88,7 @@ class CB::TeamUpdate < CB::TeamAction
       "name"          => name,
     }
 
-    output << team_details(team) << "\n"
+    output_team_details(team)
   end
 end
 


### PR DESCRIPTION
Add an enum value for a list output format.

This format should typically be a two column 'key-value' style list.

For example:
```
  ID:   123abc
  Name: example
```
Also, as an example of it's usage, we update `TeamInfo` to use this enum. As well as update the action to use the `TableBuilder` to generate this output format.