### PR TITLE
Allow API key secret-only login and usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cb upgrade status` returns maintenance window information
 - `cb upgrade start` command accepts `--starting-from` and `--now` options that
    specify upgrade failover window.
+- Specifying an application ID when adding an API key is no longer necessary. A
+  "prefixed" API key starting with `cbkey_` is necessary for use with cb. (All
+  new API keys are prefixed.)
 
 ### Fixed
 - Fix `--network` not being honored when passed with `cb create --replica`.

--- a/src/cb/creds.cr
+++ b/src/cb/creds.cr
@@ -5,12 +5,11 @@ struct CB::Creds
   include JSON::Serializable
 
   getter host : String
-  getter id : String
   getter secret : String
 
   CONFIG = Dirs::CONFIG
 
-  def initialize(@host, @id, @secret)
+  def initialize(@host, @secret)
   end
 
   def self.for_host(host) : Creds?

--- a/src/cb/login.cr
+++ b/src/cb/login.cr
@@ -6,15 +6,9 @@ class CB::Login < CB::Action
 
     raise CB::Program::Error.new "No valid credentials found. Please login." unless output.tty?
     hint = "from https://www.crunchybridge.com/account" if host == "api.crunchybridge.com"
-    output.puts "add credentials for #{host.colorize.t_name} #{hint}>"
-    output.print "  application ID: "
-    id = input.gets
-    if id.nil? || id.empty?
-      STDERR.puts "#{"error".colorize.red.bold}: application ID must be present"
-      exit 1
-    end
+    output.puts "add credentials for #{host.colorize.t_name} #{hint}"
 
-    print "  application secret: "
+    output.print "  application secret: "
     secret = input.noecho { input.gets }
     output.print "\n"
     if secret.nil? || secret.empty?
@@ -22,6 +16,6 @@ class CB::Login < CB::Action
       exit 1
     end
 
-    Creds.new(host, id, secret).store
+    Creds.new(host, secret).store
   end
 end

--- a/src/client/client.cr
+++ b/src/client/client.cr
@@ -24,12 +24,16 @@ module CB
     end
 
     def self.get_token(creds : Creds) : Token
+      unless creds.secret.starts_with?("cbkey_")
+        STDERR << "error".colorize.t_warn << ": You're using an outdated API key. Please procure a new one with `cb login` to continue.\n"
+        exit 1
+      end
+
       req = {
         "grant_type"    => "client_credential",
-        "client_id"     => creds.id,
         "client_secret" => creds.secret,
       }
-      resp = HTTP::Client.post("https://#{creds.host}/token", form: req, tls: tls)
+      resp = HTTP::Client.post("https://#{creds.host}/access-tokens", form: req, tls: tls)
       raise Error.new("post", "token", resp) unless resp.status.success?
 
       parsed = JSON.parse(resp.body)


### PR DESCRIPTION
API keys have both an application ID and application secret, and
previously both of them were required to use one. At some point we
realized this hadn't really been entirely thought through and wasn't
really necessary since API key secrets already have plenty of entropy by
themselves, and as of mid-June last year we started to allow secret-only
authentication in the API. Newer secrets were prefixed with `cbkey_` so
that we could easily distinguish an API key secret from other types of
secrets that might be used for authentication (like an access token
secret).

Here, support secret-only authentication in cb. This makes `cb login` a
bit faster to use since you only need to copy in one value.

The downside to the approach I've built here is that we'd have to force
anyone with an older API key to rotate it to continue using a new
version of cb. I figure this might be okay though since we've been
issuing newer style API keys for seven months now, and a lot of people
will already have rotated theirs organically.

The other alternative is that we could continue to try and read an
application ID from `creds` but just stop storing one. When reading one,
allow ID to be empty on newer API keys, but use ID if an old one is
detected, and only error in the case there's no ID and the API key is
old. This would have improved backward compatibility, but make the code
a bit cruftier and more complex. I opted for the simpler alternative,
but don't mind implementing it this way if it's preferable.