### PR TITLE
Implement command for `cb open` to open a Dashboard session

### DIFF
--- a/spec/cb/open_spec.cr
+++ b/spec/cb/open_spec.cr
@@ -1,0 +1,46 @@
+require "../spec_helper"
+include CB
+
+Spectator.describe CB::Open do
+  subject(action) { described_class.new client: client, output: IO::Memory.new }
+
+  let(client_host) { "api.crunchybridge.com" }
+  let(session_id) { "af73g4rdcuyo3ol766fkmtfb3y" }
+  let(session_one_time_token) { "cbott_one_time_token_secret" }
+
+  mock_client
+
+  describe ".open_command" do
+    it "successfully returns the name of an executable" do
+      expect(action.class.open_command).to_not be_nil
+    end
+  end
+
+  describe "#call" do
+    before_each do
+      client.host = client_host
+    end
+
+    it "creates a session and executes open" do
+      open_args : Array(String)? = nil
+
+      action.open = ->(args : Array(String), _env : Process::Env) do
+        open_args = args
+        nil
+      end
+
+      expect(client).to receive(:create_session)
+        .with(
+          Client::SessionCreateParams.new(generate_one_time_token: true)
+        )
+        .and_return(
+          Client::Session.new(id: session_id, one_time_token: session_one_time_token)
+        )
+
+      action.call
+
+      expected_login_url = "https://#{client_host}/sessions/#{session_id}/actions/login?one_time_token=#{session_one_time_token}"
+      expect(open_args).to eq([expected_login_url])
+    end
+  end
+end

--- a/src/cb/open.cr
+++ b/src/cb/open.cr
@@ -1,0 +1,45 @@
+require "./action"
+
+module CB
+  # Uses the API key bundled into cb to open a Dashboard session for them by
+  # creating a session and opening a browser via appropriate system command.
+  class Open < APIAction
+    # Make the open command stub-able for testing purposes.
+    property open : Proc(Array(String), Process::Env, NoReturn?)
+
+    # At compile time is bundled with the name of an executable that can be made
+    # to open a web browser to a URL on a target system.
+    def self.open_command
+      {% if flag?(:darwin) %}
+        "open"
+      {% elsif flag?(:linux) %}
+        "xdg-open"
+      {% else %}
+        raise Error.new "Sorry, don't know how to open a web browser on your operating system"
+      {% end %}
+    end
+
+    def initialize(@client, @input = STDIN, @output = STDOUT)
+      @open = ->(args : Array(String), env : Process::Env) { Process.exec(self.class.open_command, args, env: env) }
+    end
+
+    def run
+      session = client.create_session Client::SessionCreateParams.new(generate_one_time_token: true)
+
+      # A one-time token is sent via query string since we don't have any choice
+      # while using an executable like `open`, which means that there is some
+      # potential danger of it leaking to logs. To protect against this, tokens
+      # are always burned by the API on first sight, so unless the request fails
+      # before entering the API stack, it'll never be possible to retry logging
+      # in with this session. One-time tokens are also automatically expired a
+      # minute after first creation, so they must always be used immediately.
+      login_url = "https://#{client.host}/sessions/#{session.id}/actions/login?one_time_token=#{session.one_time_token}"
+
+      begin
+        self.open.call([login_url], {} of String => String)
+      rescue e : File::NotFoundError
+        raise Error.new "Command '#{self.class.open_command}' could not be found"
+      end
+    end
+  end
+end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -75,6 +75,14 @@ op = OptionParser.new do |parser|
     positional_args info.cluster_id
   end
 
+  # Opens the Bridge dashboard.
+  #
+  # This is hidden from help because it's largely used for internal use.
+  parser.on("open") do
+    parser.banner = "cb open"
+    set_action Open
+  end
+
   parser.on("rename", "Change cluster name") do
     parser.banner = "cb rename <cluster id> <new name>"
     rename = set_action ClusterRename

--- a/src/client/session.cr
+++ b/src/client/session.cr
@@ -1,0 +1,15 @@
+module CB
+  class Client
+    jrecord Session,
+      id : String,
+      one_time_token : String
+
+    jrecord SessionCreateParams, generate_one_time_token : Bool
+
+    # https://crunchybridgeapiinternal.docs.apiary.io/#reference/0/sessions/create-session
+    def create_session(params : SessionCreateParams)
+      resp = post "sessions", params
+      Session.from_json resp.body
+    end
+  end
+end

--- a/src/ext/option_parser.cr
+++ b/src/ext/option_parser.cr
@@ -4,6 +4,9 @@ class OptionParser
   property examples : String?
 
   # Allows for hiding an option from help.
+  #
+  # Note the only difference between this and the most commonly used form of
+  # `#on` is that the `description` string is omitted.
   def on(flag : String, &block : String ->)
     flag, value_type = parse_flag_definition(flag)
     @handlers[flag] = Handler.new(value_type, block)


### PR DESCRIPTION
Here, we implement a new command: `cb open`. It uses the API key bundled
into cb to create a session via API, then pops a web browser using a
system command like `open` on Mac or `xdg-open` on Linux to log the user
into the session via use of a one-time token (see [1] for background).

I'm not fully decided on the longer term survival of this feature (at
least with its current implementation) because although secure, it does
have does have to make a concession that's suboptimal for security.
Because commands like `open` can only support a `GET` request, one-time
tokens are sent via query parameter instead of body, which means they
could conceivably land in a log somewhere, even if the request itself is
operating over a secure channel.

We do take steps to keep one-time tokens secure -- they're named such
because they're always burned the first time the API ever sees one,
regardless of whether the request succeeds or not. So by the time it
ever leaks into a log, it should already be useless. One-time tokens are
also only usable within one minute of creation, so it's not possible to
not use on and have it linger around as a possible backdoor.

Still, it'd probably be overall better if more of this functionality was
pushed into the browser, but to make that happen, the Frontend would
have to be fully aware of login functionality, which is a much larger
project given its pace of change. So the idea here is to get something
in that works, and then come up with a more optimal fully-formed solution
later on.

In order to not make people too dependent on `cb open` in case we want
to change something, it's hidden from the `cb help` list so that it'll
generally only be used by those who already know about it.

[1] https://github.com/CrunchyData/priv-all-cloud-owl/pull/2252
