### PR TITLE
Refactor action confirmation prompt.

### DIFF
--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -160,6 +160,14 @@ module CB
       true
     end
 
+    private def confirm_action(action, type, name)
+      output << "About to #{action.colorize.t_warn} #{type} #{name.colorize.t_name}.\n"
+      output << "  Type the #{type}'s name to confirm: "
+      response = input.gets
+
+      raise Error.new "Response did not match, did not #{action} #{type}." unless response == name
+    end
+
     # Format floats such that if there are no significant digits to the right of
     # the decimal that it will simply format it as if it were an integer.
     # Effectively this is just simply truncating the formatted value.

--- a/src/cb/cluster_destroy.cr
+++ b/src/cb/cluster_destroy.cr
@@ -14,16 +14,7 @@ class CB::ClusterDestroy < CB::APIAction
     validate
 
     c = client.get_cluster cluster_id[:cluster]
-
-    unless confirmed
-      output << "About to " << "delete".colorize.t_warn << " cluster " << c.name.colorize.t_name
-      output << ".\n  Type the cluster's name to confirm: "
-      response = input.gets
-
-      if !(c.name == response)
-        raise Error.new "Response did not match, did not delete the cluster"
-      end
-    end
+    confirm_action("destroy", "cluster", c.name) unless confirmed
 
     client.destroy_cluster c.id
     output << "Cluster #{c.id.colorize.t_id} destroyed\n"

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -24,18 +24,7 @@ class CB::UpgradeStart < CB::Upgrade
     validate
 
     c = client.get_cluster cluster_id
-
-    unless confirmed
-      output << "About to " << "upgrade".colorize.t_warn << " cluster " << c.name.colorize.t_name
-      output << ".\n  Type the cluster's name to confirm: "
-      response = input.gets
-
-      if c.name == response
-        self.confirmed = true
-      else
-        raise Error.new "Response did not match, did not upgrade the cluster"
-      end
-    end
+    confirm_action("upgrade", "cluster", c.name) unless confirmed
 
     client.upgrade_cluster self
     output.puts "  Cluster #{c.id.colorize.t_id} upgrade started."

--- a/src/cb/detach.cr
+++ b/src/cb/detach.cr
@@ -14,16 +14,7 @@ class CB::Detach < CB::APIAction
     validate
 
     c = client.get_cluster cluster_id[:cluster]
-
-    unless confirmed
-      output << "About to " << "detach".colorize.t_warn << " cluster " << c.name.colorize.t_name
-      output << ".\n  Type the cluster's name to confirm: "
-      response = input.gets
-
-      if !(c.name == response)
-        raise Error.new "Response did not match, did not detach the cluster"
-      end
-    end
+    confirm_action("detach", "cluster", c.name) unless confirmed
 
     client.detach_cluster cluster_id[:cluster]
     output.puts "Cluster #{c.id.colorize.t_id} detached."

--- a/src/cb/restart.cr
+++ b/src/cb/restart.cr
@@ -15,18 +15,7 @@ class CB::Restart < CB::APIAction
     validate
 
     c = client.get_cluster cluster_id[:cluster]
-
-    unless confirmed
-      output << "About to " << "restart".colorize.t_warn << " cluster " << c.name.colorize.t_name
-      output << ".\n  Type the cluster's name to confirm: "
-      response = input.gets
-
-      if c.name == response
-        self.confirmed = true
-      else
-        raise Error.new "Response did not match, did not restart the cluster."
-      end
-    end
+    confirm_action("restart", "cluster", c.name) unless confirmed
 
     service = full ? "server" : "postgres"
 

--- a/src/cb/team.cr
+++ b/src/cb/team.cr
@@ -74,12 +74,7 @@ class CB::TeamUpdate < CB::TeamAction
 
     unless confirmed
       t = client.get_team team_id
-
-      output.printf "About to %s team %s.\n", "update".colorize.t_warn, t.name.colorize.t_name
-      output.printf "  Type the team's name to confirm: "
-      response = input.gets
-
-      raise Error.new "Response did not match, did not update the team" unless response == t.name
+      confirm_action("update", "team", t.name)
     end
 
     team = client.update_team team_id, {
@@ -102,12 +97,7 @@ class CB::TeamDestroy < CB::TeamAction
 
     unless confirmed
       t = client.get_team team_id
-
-      output.printf "About to %s team %s.\n", "delete".colorize.t_warn, t.name.colorize.t_name
-      output.printf "  Type the team's name to confirm: "
-      response = input.gets
-
-      raise Error.new "Response did not match, did not delete the team." unless response == t.name
+      confirm_action("destroy", "team", t.name)
     end
 
     team = client.destroy_team team_id

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -146,7 +146,11 @@ module CB
       Cluster.from_json resp.body
     end
 
-    def destroy_cluster(id)
+    def destroy_cluster(id : String)
+      destroy_cluster Identifier.new(id)
+    end
+
+    def destroy_cluster(id : Identifier)
       resp = delete "clusters/#{id}"
       ClusterDetail.from_json resp.body
     end


### PR DESCRIPTION
Refactor action confirmation prompt so that it can be reused by multiple actions, eliminating the need for actions to re-implement.