### PR TITLE
Update `firewall_rules` client.

### DIFF
--- a/src/cb/manage_firewall.cr
+++ b/src/cb/manage_firewall.cr
@@ -2,6 +2,7 @@ class CB::ManageFirewall < CB::APIAction
   Error = Program::Error
 
   eid_setter cluster_id
+  property network_id : String?
   property to_add = [] of String
   property to_remove = [] of String
 
@@ -15,6 +16,7 @@ class CB::ManageFirewall < CB::APIAction
 
   def run
     raise Error.new "--cluster not set" unless cluster_id
+    @network_id = @client.get_cluster(cluster_id).network_id
     remove_all
     add_all
     display_rules
@@ -22,7 +24,7 @@ class CB::ManageFirewall < CB::APIAction
 
   def remove_all
     return if to_remove.empty?
-    current_rules = @client.get_firewall_rules(cluster_id)
+    current_rules = @client.get_firewall_rules(@network_id)
 
     to_remove.uniq.each do |cidr|
       cidr_str = cidr.colorize.t_name
@@ -42,7 +44,7 @@ class CB::ManageFirewall < CB::APIAction
   end
 
   def display_rules
-    current_rules = @client.get_firewall_rules(cluster_id)
+    current_rules = @client.get_firewall_rules(@network_id)
 
     pad = if output.tty?
             output.puts "allowed cidrs:"
@@ -56,14 +58,14 @@ class CB::ManageFirewall < CB::APIAction
   end
 
   def remove_rule(rule : Client::FirewallRule)
-    @client.delete_firewall_rule cluster_id, rule.id
+    @client.delete_firewall_rule @network_id, rule.id
     "done".colorize.t_success
   rescue e : Client::Error
     output.print e
   end
 
   def add_rule(cidr : String)
-    @client.add_firewall_rule cluster_id, cidr
+    @client.add_firewall_rule @network_id, cidr
     "done".colorize.t_success
   rescue e : Client::Error
     output.print e

--- a/src/client/firewall_rule.cr
+++ b/src/client/firewall_rule.cr
@@ -6,23 +6,23 @@ module CB
 
     # Add a firewall rule to a cluster.
     #
-    # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridfirewall/create-firewall-rule
-    def add_firewall_rule(cluster_id, cidr)
-      post "clusters/#{cluster_id}/firewall", {rule: cidr}
+    # TODO (abrightwell): Add docs reference.
+    def add_firewall_rule(network_id, cidr)
+      post "networks/#{network_id}/firewall-rules", {rule: cidr}
     end
 
     # Remove a firewall rule from a cluster.
     #
-    # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridfirewallruleid/destroy-firewall-rule
-    def delete_firewall_rule(cluster_id, firewall_rule_id)
-      delete "clusters/#{cluster_id}/firewall/#{firewall_rule_id}"
+    # TODO (abrightwell): Add docs reference.
+    def delete_firewall_rule(network_id, firewall_rule_id)
+      delete "networks/#{network_id}/firewall-rules/#{firewall_rule_id}"
     end
 
     # List current firewall rules for a cluster.
     #
-    # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridfirewall/list-firewall-rules
-    def get_firewall_rules(cluster_id)
-      resp = get "clusters/#{cluster_id}/firewall"
+    # TODO (abrightwell): Add docs reference.
+    def get_firewall_rules(network_id)
+      resp = get "networks/#{network_id}/firewall-rules"
       Array(FirewallRule).from_json resp.body, root: "firewall_rules"
     end
   end


### PR DESCRIPTION
Here we're updating the client to use the new
`/networks/:id/firewall-rules` endpoints that are now available in the API.

There are no functional changes to the CLI. This only affects the underlying client.