### PR TITLE
Fix `network` lookup on `cb info`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.envrc
+
 /docs/
 /lib/
 /bin/

--- a/spec/cb/cluster_info_spec.cr
+++ b/spec/cb/cluster_info_spec.cr
@@ -24,7 +24,7 @@ Spectator.describe CB::ClusterInfo do
 
       expect(client).to receive(:get_cluster).with(action.cluster_id[:cluster]).and_return cluster
       expect(client).to receive(:get_team).with(cluster.team_id).and_return team
-      expect(client).to receive(:get_firewall_rules).with(cluster.id).and_return [] of Client::FirewallRule
+      expect(client).to receive(:get_firewall_rules).with(cluster.network_id).and_return [] of Client::FirewallRule
 
       action.call
 

--- a/src/cb/cluster_info.cr
+++ b/src/cb/cluster_info.cr
@@ -41,7 +41,7 @@ class CB::ClusterInfo < CB::APIAction
       output << v << "\n"
     end
 
-    firewall_rules = client.get_firewall_rules c.id
+    firewall_rules = client.get_firewall_rules c.network_id
     output << "firewall".rjust(pad).colorize.bold << ": "
     if firewall_rules.empty?
       output << "no rules\n"


### PR DESCRIPTION
After changing over the client to use the new
`/network/:id` endpoints, we forgot to update the client call in
`cluster_info`. So it was continuing to request the cluster id instead
of the network id for firewall rules. We fix that here.
