### PR TITLE
Add `--team` option to `cb list`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 completion.log
 /dist/
 /vendor/
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `cb list` command now accepts `--format`. Supports: `table` and `tree`.
+- `cb list` command now accepts `--team`.
 
 ## [3.2.0] - 2023-02-28
 ### Added

--- a/src/cb/cluster_list.cr
+++ b/src/cb/cluster_list.cr
@@ -12,7 +12,12 @@ class CB::List < CB::APIAction
     # If the format is tree, then we don't need to flatten the results.
     flatten = !(format == CB::Format::Tree)
     teams = client.get_teams
-    clusters = client.get_clusters(teams, flatten)
+
+    clusters = if team_id
+                 client.get_clusters(team_id)
+               else
+                 client.get_clusters(teams, flatten)
+               end
 
     data = Hash(String, Array(CB::Client::Cluster)).new do |hash, key|
       hash[key] = [] of CB::Client::Cluster

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -80,6 +80,9 @@ op = OptionParser.new do |parser|
 
     List all clusters. Output: tree
     $ cb list --format=tree
+
+    List all clusters for a single team.
+    $ cb list --team <ID>
     EXAMPLES
   end
 

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -37,7 +37,7 @@ module CB
       result
     end
 
-    def get_clusters(team_id : String)
+    def get_clusters(team_id)
       resp = get "clusters?team_id=#{team_id}"
       Array(Cluster).from_json resp.body, root: "clusters"
     end


### PR DESCRIPTION
Here were implementing the `--team` option in `cb list`.  The flag was inadvertently added in #97, but the intent was always to follow up with this feature. So, we go ahead and make it happen here.

Ultimately, the idea is to allow a user to specify an individual team to filter the results. As opposed to always returning all clusters for all teams which they have access to.

Based on #97 until merged.