### PR TITLE
Refactor API resource models to `CB::Model` module.

### DIFF
--- a/spec/cb/client/cluster_spec.cr
+++ b/spec/cb/client/cluster_spec.cr
@@ -7,12 +7,12 @@ Spectator.describe CB::Client do
 
   describe "#flatten_clusters" do
     it "handles no clusters" do
-      clusters = [] of CB::Client::Cluster
+      clusters = [] of CB::Model::Cluster
       expect(&.flatten_clusters(clusters)).to be_empty
     end
 
     it "handles clusters without replicas" do
-      clusters = [CB::Client::Cluster.new(
+      clusters = [CB::Model::Cluster.new(
         id: "pkdpq6yynjgjbps4otxd7il2u4",
         team_id: "l2gnkxjv3beifk6abkraerv7de",
         name: "abc",
@@ -24,17 +24,17 @@ Spectator.describe CB::Client do
     end
 
     it "handles clusters with replicas" do
-      clusters = [CB::Client::Cluster.new(
+      clusters = [CB::Model::Cluster.new(
         id: "pkdpq6yynjgjbps4otxd7il2u4",
         team_id: "l2gnkxjv3beifk6abkraerv7de",
         name: "abc",
         replicas: [
-          CB::Client::Cluster.new(
+          CB::Model::Cluster.new(
             id: "replica_id",
             team_id: "l2gnkxjv3beifk6abkraerv7de",
             name: "replica of abc",
             replicas: [
-              CB::Client::Cluster.new(
+              CB::Model::Cluster.new(
                 id: "replica_of_replica_id",
                 team_id: "l2gnkxjv3beifk6abkraerv7de",
                 name: "replica of replica",

--- a/spec/cb/cluster_create_spec.cr
+++ b/spec/cb/cluster_create_spec.cr
@@ -115,11 +115,10 @@ Spectator.describe CB::ClusterCreate do
       action.region = "east"
       action.team = team.id
 
-      expect(client).to receive(:create_cluster).and_return(CB::Client::Cluster.new("abc", "def", "my cluster", [] of CB::Client::Cluster))
-
+      expect(client).to receive(:create_cluster).and_return(cluster)
       action.call
 
-      expect(&.output.to_s).to eq "Created cluster abc \"my cluster\"\n"
+      expect(&.output.to_s).to eq "Created cluster pkdpq6yynjgjbps4otxd7il2u4 \"abc\"\n"
     end
   end
 

--- a/spec/cb/cluster_info_spec.cr
+++ b/spec/cb/cluster_info_spec.cr
@@ -7,6 +7,7 @@ Spectator.describe CB::ClusterInfo do
 
   let(team) { Factory.team }
   let(cluster) { Factory.cluster }
+  let(cluster_status) { Factory.cluster_status }
 
   describe "#validate" do
     it "ensures required arguments are present" do
@@ -23,6 +24,7 @@ Spectator.describe CB::ClusterInfo do
       action.cluster_id = team.id + "/" + cluster.id
 
       expect(client).to receive(:get_cluster).with(action.cluster_id[:cluster]).and_return cluster
+      expect(client).to receive(:get_cluster_status).and_return cluster_status
       expect(client).to receive(:get_team).with(cluster.team_id).and_return team
       expect(client).to receive(:get_firewall_rules).with(cluster.network_id).and_return [] of Client::FirewallRule
 
@@ -30,7 +32,7 @@ Spectator.describe CB::ClusterInfo do
 
       expected = <<-EXPECTED
       Test Team/abc
-                     state: na
+                     state: ready
                       host: p.pkdpq6yynjgjbps4otxd7il2u4.example.com
                    created: 2016-02-15T10:20:30Z
                       plan: memory-4 (111GiB ram, 4vCPU)

--- a/spec/cb/cluster_list_spec.cr
+++ b/spec/cb/cluster_list_spec.cr
@@ -20,8 +20,8 @@ Spectator.describe CB::List do
         .with(Array(CB::Client::Team), Bool)
         .and_return(
           [
-            CB::Client::Cluster.new("abc", team.id, "my cluster", nil),
-            CB::Client::Cluster.new("replica-id", team.id, "my replica", nil),
+            CB::Model::Cluster.new(id: "abc", team_id: team.id, name: "my cluster"),
+            CB::Model::Cluster.new(id: "replica-id", team_id: team.id, name: "my replica"),
           ])
 
       action.call
@@ -42,8 +42,8 @@ Spectator.describe CB::List do
         .with(Array(CB::Client::Team), Bool)
         .and_return(
           [
-            CB::Client::Cluster.new("abc", team.id, "my cluster", [
-              CB::Client::Cluster.new("replica-id", team.id, "my replica", nil),
+            CB::Model::Cluster.new(id: "abc", team_id: team.id, name: "my cluster", replicas: [
+              CB::Model::Cluster.new(id: "replica-id", team_id: team.id, name: "my replica"),
             ]),
           ])
 

--- a/spec/cb/cluster_list_spec.cr
+++ b/spec/cb/cluster_list_spec.cr
@@ -17,7 +17,7 @@ Spectator.describe CB::List do
 
       # Cluster results should be flattened.
       expect(client).to receive(:get_clusters)
-        .with(Array(CB::Client::Team), Bool)
+        .with(Array(CB::Model::Team), Bool)
         .and_return(
           [
             CB::Model::Cluster.new(id: "abc", team_id: team.id, name: "my cluster"),
@@ -39,7 +39,7 @@ Spectator.describe CB::List do
       action.format = CB::Format::Tree
 
       expect(client).to receive(:get_clusters)
-        .with(Array(CB::Client::Team), Bool)
+        .with(Array(CB::Model::Team), Bool)
         .and_return(
           [
             CB::Model::Cluster.new(id: "abc", team_id: team.id, name: "my cluster", replicas: [

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -19,7 +19,7 @@ Spectator.describe CB::UpgradeStart do
     action.confirmed = true
 
     expect(client).to receive(:get_cluster).and_return(cluster)
-    expect(client).to receive(:upgrade_cluster).and_return([] of CB::Client::Operation)
+    expect(client).to receive(:upgrade_cluster).and_return([] of CB::Model::Operation)
 
     action.call
 
@@ -50,7 +50,7 @@ Spectator.describe CB::UpgradeMaintenanceCreate do
       action.confirmed = true
 
       expect(client).to receive(:get_cluster).and_return(cluster)
-      expect(client).to receive(:upgrade_cluster).and_return([] of CB::Client::Operation)
+      expect(client).to receive(:upgrade_cluster).and_return([] of CB::Model::Operation)
 
       action.call
 
@@ -79,7 +79,7 @@ Spectator.describe CB::UpgradeStatus do
 
     expect(client).to receive(:get_cluster).and_return(cluster)
     expect(client).to receive(:get_team).and_return(team)
-    expect(client).to receive(:upgrade_cluster_status).and_return([] of CB::Client::Operation)
+    expect(client).to receive(:upgrade_cluster_status).and_return([] of CB::Model::Operation)
 
     action.call
 
@@ -97,14 +97,14 @@ Spectator.describe CB::UpgradeStatus do
 
     expect(client).to receive(:get_cluster).and_return(cluster)
     expect(client).to receive(:get_team).and_return(team)
-    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("ha_change", "fake", nil)])
+    expect(client).to receive(:upgrade_cluster_status).and_return([Factory.operation(flavor: CB::Model::Operation::Flavor::HAChange)])
 
     action.call
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
       maintenance window: no window set. Default to: 00:00-23:59
-               ha_change: fake\n
+               ha_change: in_progress\n
     EXPECTED
 
     expect(&.output.to_s).to eq expected
@@ -115,14 +115,14 @@ Spectator.describe CB::UpgradeStatus do
 
     expect(client).to receive(:get_cluster).and_return(cluster)
     expect(client).to receive(:get_team).and_return(team)
-    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("resize", "fake", "2022-01-01T00:00:00Z")])
+    expect(client).to receive(:upgrade_cluster_status).and_return([Factory.operation(starting_from: "2022-01-01T00:00:00Z")])
 
     action.call
 
     expected = <<-EXPECTED
   #{team.name}/#{cluster.name}
     maintenance window: no window set. Default to: 00:00-23:59
-                resize: fake (Starting from: 2022-01-01T00:00:00Z)\n
+                resize: in_progress (Starting from: 2022-01-01T00:00:00Z)\n
   EXPECTED
 
     expect(&.output.to_s).to eq expected
@@ -134,7 +134,7 @@ Spectator.describe CB::UpgradeStatus do
 
     expect(client).to receive(:get_cluster).and_return(cluster)
     expect(client).to receive(:get_team).and_return(team)
-    expect(client).to receive(:upgrade_cluster_status).and_return([CB::Client::Operation.new("ha_change", "fake", nil)])
+    expect(client).to receive(:upgrade_cluster_status).and_return([] of CB::Model::Operation)
 
     action.call
 

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private class CompletionTestClient < CB::Client
-  def get_clusters(teams : Array(CB::Client::Team)? = nil)
+  def get_clusters(teams : Array(CB::Model::Team)? = nil, flatten : Bool = false)
     [Factory.cluster]
   end
 

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -100,6 +100,16 @@ module Factory
     CB::Client::Network.new **params
   end
 
+  def operation(**params)
+    params = {
+      flavor:        CB::Model::Operation::Flavor::Resize,
+      state:         CB::Model::Operation::State::InProgress,
+      starting_from: nil,
+    }.merge(params)
+
+    CB::Model::Operation.new **params
+  end
+
   def user_role(**params)
     params = {
       account_email: "user@example.com",

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -131,7 +131,7 @@ module Factory
       enforce_sso:   nil,
     }.merge(params)
 
-    CB::Client::Team.new **params
+    CB::Model::Team.new **params
   end
 
   def team_member(**params)

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -62,14 +62,12 @@ module Factory
       host:                     "p.pkdpq6yynjgjbps4otxd7il2u4.example.com",
       team_id:                  "l2gnkxjv3beifk6abkraerv7de",
       name:                     "abc",
-      state:                    "na",
       created_at:               Time.utc(2016, 2, 15, 10, 20, 30),
       is_ha:                    false,
       major_version:            12,
       plan_id:                  "memory-4",
       cpu:                      4.0,
       memory:                   111.0,
-      oldest_backup:            nil,
       provider_id:              "aws",
       region_id:                "us-east-2",
       maintenance_window_start: nil,
@@ -77,7 +75,16 @@ module Factory
       storage:                  1234,
     }.merge(params)
 
-    CB::Client::ClusterDetail.new **params
+    CB::Model::Cluster.new **params
+  end
+
+  def cluster_status(**params)
+    params = {
+      oldest_backup_at: nil,
+      state:            CB::Model::ClusterStatus::State::Ready,
+    }.merge(params)
+
+    CB::Model::ClusterStatus.new **params
   end
 
   def network(**params)

--- a/src/cb/cluster_info.cr
+++ b/src/cb/cluster_info.cr
@@ -13,11 +13,12 @@ class CB::ClusterInfo < CB::APIAction
     validate
 
     c = client.get_cluster(cluster_id[:cluster])
+    cluster_status = client.get_cluster_status cluster_id: c.id
 
     print_team_slash_cluster c
 
     details = {
-      "state"              => c.state,
+      "state"              => cluster_status.state,
       "host"               => c.host,
       "created"            => c.created_at.to_rfc3339,
       "plan"               => "#{c.plan_id} (#{format(c.memory)}GiB ram, #{format(c.cpu)}vCPU)",

--- a/src/cb/cluster_list.cr
+++ b/src/cb/cluster_list.cr
@@ -19,8 +19,8 @@ class CB::List < CB::APIAction
                  client.get_clusters(teams, flatten)
                end
 
-    data = Hash(String, Array(CB::Client::Cluster)).new do |hash, key|
-      hash[key] = [] of CB::Client::Cluster
+    data = Hash(String, Array(CB::Model::Cluster)).new do |hash, key|
+      hash[key] = [] of CB::Model::Cluster
     end
 
     clusters.each do |c|

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -20,11 +20,11 @@ abstract class CB::Upgrade < CB::APIAction
     operation_kind = "operations"
     if maintenance_only
       operation_kind = "maintenance operations"
-      operations = operations.select { |op| op.flavor != "ha_change" }
+      operations = operations.select { |op| op.flavor != CB::Model::Operation::Flavor::HAChange }
     end
 
     operations.each do |op|
-      details[op.flavor] = op.one_line_state_display
+      details[op.flavor.to_s] = op.one_line_state_display
     end
 
     if operations.empty?

--- a/src/cb/models/cluster.cr
+++ b/src/cb/models/cluster.cr
@@ -1,0 +1,62 @@
+require "json"
+
+module CB::Model
+  struct Cluster
+    include JSON::Serializable
+
+    property cpu : Float64
+
+    property id : String
+
+    property created_at : Time
+
+    property host : String
+
+    property is_ha : Bool
+
+    property maintenance_window_start : Int32?
+
+    property major_version : Int32
+
+    property memory : Float64
+
+    property name : String
+
+    property network_id : String
+
+    property plan_id : String
+
+    property provider_id : String
+
+    property region_id : String
+
+    property replicas : Array(Cluster)?
+
+    @[JSON::Field(key: "cluster_id")]
+    property source_cluster_id : String?
+
+    property storage : Int32
+
+    property tailscale_active : Bool
+
+    property team_id : String
+
+    def initialize(@id, @name, @team_id,
+                   @cpu = 0.0,
+                   @created_at = Time::ZERO,
+                   @host = "",
+                   @is_ha = false,
+                   @maintenance_window_start = nil,
+                   @major_version = 0,
+                   @memory = 0,
+                   @network_id = "",
+                   @plan_id = "",
+                   @provider_id = "",
+                   @region_id = "",
+                   @replicas = nil,
+                   @source_cluster_id = nil,
+                   @storage = 0,
+                   @tailscale_active = false)
+    end
+  end
+end

--- a/src/cb/models/cluster_status.cr
+++ b/src/cb/models/cluster_status.cr
@@ -1,0 +1,25 @@
+require "json"
+
+module CB::Model
+  struct ClusterStatus
+    include JSON::Serializable
+
+    enum State
+      Creating
+      Destroying
+      Unknown
+      Ready
+      Restarting
+
+      def to_s(io : IO)
+        io << self.to_s.downcase
+      end
+    end
+
+    property oldest_backup_at : String?
+    property state : State
+
+    def initialize(@oldest_backup_at = nil, @state = State::Unknown)
+    end
+  end
+end

--- a/src/cb/models/operation.cr
+++ b/src/cb/models/operation.cr
@@ -1,0 +1,56 @@
+require "json"
+
+module CB::Model
+  # Upgrade operation.
+  struct Operation
+    include JSON::Serializable
+
+    enum Flavor
+      HAChange
+      Maintenance
+      MajorVersionUpgrade
+      Resize
+
+      def to_s
+        super.to_s.underscore
+      end
+
+      def to_s(io : IO) : Nil
+        io << to_s
+      end
+    end
+
+    enum State
+      Creating
+      DisablingHA
+      EnablingHA
+      FailingOver
+      InProgress
+      Ready
+      Scheduled
+      WaitingForHAStandby
+
+      def to_s
+        super.to_s.underscore
+      end
+
+      def to_s(io : IO) : Nil
+        io << to_s
+      end
+    end
+
+    property flavor : Flavor
+    property state : State
+    property starting_from : String?
+
+    def initialize(@flavor : Flavor,
+                   @state : State,
+                   @starting_from : String? = nil)
+    end
+
+    def one_line_state_display
+      from = " (Starting from: #{starting_from})" if starting_from
+      "#{state}#{from}"
+    end
+  end
+end

--- a/src/cb/models/team.cr
+++ b/src/cb/models/team.cr
@@ -1,0 +1,33 @@
+require "json"
+
+module CB::Model
+  struct Team
+    include JSON::Serializable
+
+    property billing_email : String?
+
+    property id : String
+
+    property is_personal : Bool
+
+    property name : String
+
+    property role : String?
+
+    property enforce_sso : Bool?
+
+    def initialize(@id, @name, @is_personal,
+                   @billing_email = nil,
+                   @enforce_sso = nil,
+                   @role = nil)
+    end
+
+    def name
+      is_personal ? "personal" : @name
+    end
+
+    def to_s(io : IO)
+      io << "#{id.colorize.t_id} (#{name.colorize.t_name})"
+    end
+  end
+end

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -26,7 +26,7 @@ class CB::RoleList < CB::RoleAction
 
   bool_setter? no_header
 
-  private property cluster : Client::ClusterDetail?
+  private property cluster : CB::Model::Cluster?
 
   private property roles : Array(Hash(String, String)) = [] of Hash(String, String)
 

--- a/src/cb/role.cr
+++ b/src/cb/role.cr
@@ -30,7 +30,7 @@ class CB::RoleList < CB::RoleAction
 
   private property roles : Array(Hash(String, String)) = [] of Hash(String, String)
 
-  private property team : Client::Team?
+  private property team : CB::Model::Team?
 
   def validate
     check_required_args do |missing|

--- a/src/cb/team.cr
+++ b/src/cb/team.cr
@@ -5,7 +5,7 @@ abstract class CB::TeamAction < CB::APIAction
 
   format_setter format
 
-  private def output_team_details(t : CB::Client::Team)
+  private def output_team_details(t : CB::Model::Team)
     table = Table::TableBuilder.new(border: :none) do
       row ["ID:", t.id.colorize.t_id]
       row ["Name:", t.name.colorize.t_name]

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -15,13 +15,13 @@ module CB
       get_clusters(get_teams)
     end
 
-    def get_clusters(teams : Array(Team), flatten : Bool = false)
+    def get_clusters(teams : Array(CB::Model::Team), flatten : Bool = false)
       result = Promise.map(teams) { |t| get_clusters t.id }.get.flatten
       result = flatten_clusters(result) if flatten
       result
     end
 
-    def flatten_clusters(clusters : Array(CB::Client::Cluster)?, result = [] of CB::Client::Cluster)
+    def flatten_clusters(clusters : Array(CB::Model::Cluster)?, result = [] of CB::Model::Cluster)
       clusters.try &.each do |cluster|
         result << cluster
         flatten_clusters(cluster.replicas, result)
@@ -30,7 +30,7 @@ module CB
       result
     end
 
-    def get_clusters(team_id : String)
+    def get_clusters(team_id)
       resp = get "clusters?team_id=#{team_id}"
       Array(CB::Model::Cluster).from_json resp.body, root: "clusters"
     end

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -3,14 +3,6 @@ require "../cb/models/*"
 
 module CB
   class Client
-    # Upgrade operation.
-    jrecord Operation, flavor : String, state : String, starting_from : String? do
-      def one_line_state_display
-        from = " (Starting from: #{starting_from})" if starting_from
-        "#{state}#{from}"
-      end
-    end
-
     def get_clusters
       get_clusters(get_teams)
     end
@@ -109,13 +101,13 @@ module CB
         storage:             uc.storage,
         starting_from:       uc.starting_from,
       }
-      Array(Operation).from_json resp.body, root: "operations"
+      Array(CB::Model::Operation).from_json resp.body, root: "operations"
     end
 
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridupgrade/get-upgrade-status
     def upgrade_cluster_status(id)
       resp = get "clusters/#{id}/upgrade"
-      Array(Operation).from_json resp.body, root: "operations"
+      Array(CB::Model::Operation).from_json resp.body, root: "operations"
     end
 
     def upgrade_cluster_cancel(id)

--- a/src/client/team.cr
+++ b/src/client/team.cr
@@ -2,30 +2,12 @@ require "./client"
 
 module CB
   class Client
-    # A team is a small organizational unit in Bridge used to group multiple users
-    # at varying levels of privilege.
-    jrecord Team,
-      id : String,
-      name : String,
-      is_personal : Bool,
-      role : String?,
-      billing_email : String? = nil,
-      enforce_sso : Bool? = nil do
-      def name
-        is_personal ? "personal" : @name
-      end
-
-      def to_s(io : IO)
-        io << id.colorize.t_id << " (" << name.colorize.t_name << ")"
-      end
-    end
-
     # Create a new team.
     #
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teams/create-team
     def create_team(name : String)
       resp = post "teams", {name: name}
-      Team.from_json resp.body
+      CB::Model::Team.from_json resp.body
     end
 
     # List available teams.
@@ -33,7 +15,7 @@ module CB
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teams/list-teams
     def get_teams
       resp = get "teams"
-      Array(Team).from_json resp.body, root: "teams"
+      Array(CB::Model::Team).from_json resp.body, root: "teams"
     end
 
     # Update a team.
@@ -44,7 +26,7 @@ module CB
       # Seems like it would be the 'safer' option maybe. Thoughts are around
       # perhaps something like `TeamUpdateOptions`.
       resp = patch "teams/#{id}", options
-      Team.from_json resp.body
+      CB::Model::Team.from_json resp.body
     end
 
     # Retrieve details about a team.
@@ -52,7 +34,7 @@ module CB
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamid/get-team
     def get_team(id)
       resp = get "teams/#{id}"
-      Team.from_json resp.body
+      CB::Model::Team.from_json resp.body
     end
 
     private def get_team_by_name(name : Identifier)
@@ -66,7 +48,7 @@ module CB
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamid/destroy-team
     def destroy_team(id)
       resp = delete "teams/#{id}"
-      Team.from_json resp.body
+      CB::Model::Team.from_json resp.body
     end
 
     def get_team_cert(id)

--- a/src/ext/stdlib_ext.cr
+++ b/src/ext/stdlib_ext.cr
@@ -42,6 +42,10 @@ macro jrecord(name, *properties)
   end
 end
 
+struct Time
+  ZERO = Time.utc(1, 1, 1, 0, 0, 0)
+end
+
 class URI
   def self.new(pull : JSON::PullParser)
     parse pull.read_string


### PR DESCRIPTION
Here start refactoring API resource models to their own module.

This is a broad refactoring project that I've been wanting to get started.

Currently, all of our API resource models are defined in our `Client`. While I think initially this was the logical place to implement and maintain them, I feel like it would be nice to give them their own namespace.

So that's what I've started doing here.

I'm finding this to be a good exercise as well, as I'm taking the opportunity to reduce redundancy in their implementation as well and updating them to be more in line with what the API currently supports. More specifically, there are some items that have been deprecated by the API as well as being able to merge redundant models such as `Cluster` and `ClusterDetails`. This is because when they were initially implemented the API treated them as separate resources and that is no longer the case.