### PR TITLE
Refactor `cb maintenance info` output.

### DIFF
--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -85,8 +85,8 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      no operations in progress
-      maintenance window: no window set. Default to: 00:00-23:59\n
+      operations:           no operations in progress               
+      maintenance window:   no window set. Default to: 00:00-23:59  \n
     EXPECTED
 
     expect(&.output.to_s).to eq expected
@@ -103,8 +103,8 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      maintenance window: no window set. Default to: 00:00-23:59
-               ha_change: in_progress\n
+      ha change:            in progress                             
+      maintenance window:   no window set. Default to: 00:00-23:59  \n
     EXPECTED
 
     expect(&.output.to_s).to eq expected
@@ -120,10 +120,10 @@ Spectator.describe CB::UpgradeStatus do
     action.call
 
     expected = <<-EXPECTED
-  #{team.name}/#{cluster.name}
-    maintenance window: no window set. Default to: 00:00-23:59
-                resize: in_progress (Starting from: 2022-01-01T00:00:00Z)\n
-  EXPECTED
+    #{team.name}/#{cluster.name}
+      resize:               in progress (Starting from: 2022-01-01T00:00:00Z)  
+      maintenance window:   no window set. Default to: 00:00-23:59             \n
+    EXPECTED
 
     expect(&.output.to_s).to eq expected
   end
@@ -140,8 +140,8 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      no maintenance operations in progress
-      maintenance window: no window set. Default to: 00:00-23:59\n
+      operations:           no operations in progress               
+      maintenance window:   no window set. Default to: 00:00-23:59  \n
     EXPECTED
 
     expect(&.output.to_s).to eq expected

--- a/src/cb/models/operation.cr
+++ b/src/cb/models/operation.cr
@@ -11,12 +11,8 @@ module CB::Model
       MajorVersionUpgrade
       Resize
 
-      def to_s
-        super.to_s.underscore
-      end
-
-      def to_s(io : IO) : Nil
-        io << to_s
+      def to_s(io : IO)
+        io << to_s.underscore.gsub('_', ' ')
       end
     end
 
@@ -30,12 +26,8 @@ module CB::Model
       Scheduled
       WaitingForHAStandby
 
-      def to_s
-        super.to_s.underscore
-      end
-
       def to_s(io : IO) : Nil
-        io << to_s
+        io << to_s.underscore.gsub('_', ' ')
       end
     end
 
@@ -46,11 +38,6 @@ module CB::Model
     def initialize(@flavor : Flavor,
                    @state : State,
                    @starting_from : String? = nil)
-    end
-
-    def one_line_state_display
-      from = " (Starting from: #{starting_from})" if starting_from
-      "#{state}#{from}"
     end
   end
 end


### PR DESCRIPTION
Here we're refactoring how the output for `cb maintenance info` is produced.

Specifically, we're moving the output code out of the `Operation` model and putting it into the action. As well, we make use of the TableBuilder that we are using in other command outputs, using it similar to how we use it with `cb team list`.

Also, as part of this we guarantee the ordering of the output elements. Specifically, we ensure that operations are always first and the `maintenance window` is always last.

Based on #101 until merged.