### PR TITLE
More model refactoring

### DIFF
--- a/spec/cb/backup_spec.cr
+++ b/spec/cb/backup_spec.cr
@@ -50,7 +50,7 @@ Spectator.describe CB::BackupList do
     it "says when there are no backups" do
       action.cluster_id = cluster.id
 
-      expect(client).to receive(:backup_list).and_return([] of CB::Client::Backup)
+      expect(client).to receive(:backup_list).and_return([] of CB::Model::Backup)
 
       action.call
 

--- a/spec/cb/cluster_info_spec.cr
+++ b/spec/cb/cluster_info_spec.cr
@@ -26,7 +26,7 @@ Spectator.describe CB::ClusterInfo do
       expect(client).to receive(:get_cluster).with(action.cluster_id[:cluster]).and_return cluster
       expect(client).to receive(:get_cluster_status).and_return cluster_status
       expect(client).to receive(:get_team).with(cluster.team_id).and_return team
-      expect(client).to receive(:get_firewall_rules).with(cluster.network_id).and_return [] of Client::FirewallRule
+      expect(client).to receive(:get_firewall_rules).with(cluster.network_id).and_return [] of CB::Model::FirewallRule
 
       action.call
 

--- a/spec/cb/cluster_uri_spec.cr
+++ b/spec/cb/cluster_uri_spec.cr
@@ -8,7 +8,7 @@ Spectator.describe CB::ClusterURI do
 
   let(account) { Factory.account }
   let(cluster) { Factory.cluster }
-  let(role) { Factory.user_role }
+  let(role) { Factory.role_user }
 
   describe "#initialize" do
     it "ensures 'default' if role not specified" do

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -15,20 +15,23 @@ private class CompletionTestClient < CB::Client
 
   def get_providers
     [
-      Provider.new(
-        "aws", "AWS",
-        plans: [Plan.new("memory-16", "Memory-16")],
-        regions: [Region.new("us-west-2", "US West 2", "Oregon")]
+      Factory.provider(
+        id: "aws",
+        display_name: "AWS",
+        plans: [Factory.plan(id: "memory-16", display_name: "Memory-16")],
+        regions: [Factory.region(id: "us-west-2", display_name: "US West 2", location: "Oregon")],
       ),
-      Provider.new(
-        "gcp", "GCP",
-        plans: [Plan.new("standard-128", "Standard-128")],
-        regions: [Region.new("us-central1", "US Central 1", "Iowa")]
+      Factory.provider(
+        id: "gcp",
+        display_name: "GCP",
+        plans: [Factory.plan(id: "standard-128", display_name: "Standard-128")],
+        regions: [Factory.region(id: "us-central1", display_name: "US Central 1", location: "Iowa")]
       ),
-      Provider.new(
-        "azure", "Azure",
-        plans: [Plan.new("standard-64", "Standard-64")],
-        regions: [Region.new("westus", "West US", "California")]
+      Factory.provider(
+        id: "azure",
+        display_name: "Azure",
+        plans: [Factory.plan(id: "standard-64", display_name: "Standard-64")],
+        regions: [Factory.region(id: "westus", display_name: "West US", location: "California")]
       ),
     ]
   end

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -34,7 +34,10 @@ private class CompletionTestClient < CB::Client
   end
 
   def get_log_destinations(id)
-    [LogDestination.new("logid", "host", 2020, "template", "logdest descr")]
+    [
+      Factory.log_destination(id: "logid", host: "host", port: 2020,
+        template: "template", description: "logdest descr"),
+    ]
   end
 end
 

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -10,7 +10,7 @@ private class CompletionTestClient < CB::Client
   end
 
   def get_firewall_rules(id)
-    [FirewallRule.new("f1", "1.2.3.4/32"), FirewallRule.new("f2", "4.5.6.7/24")]
+    [Factory.firewall_rule(id: "f1", rule: "1.2.3.4/32"), Factory.firewall_rule(id: "f2", rule: "4.5.6.7/24")]
   end
 
   def get_providers

--- a/spec/cb/open_spec.cr
+++ b/spec/cb/open_spec.cr
@@ -34,7 +34,7 @@ Spectator.describe CB::Open do
           Client::SessionCreateParams.new(generate_one_time_token: true)
         )
         .and_return(
-          Client::Session.new(id: session_id, one_time_token: session_one_time_token)
+          CB::Model::Session.new(id: session_id, one_time_token: session_one_time_token)
         )
 
       action.call

--- a/spec/cb/psql_spec.cr
+++ b/spec/cb/psql_spec.cr
@@ -11,7 +11,7 @@ Spectator.describe CB::Psql do
   end
 
   let(cluster) { Factory.cluster }
-  let(role) { Factory.user_role }
+  let(role) { Factory.role_user }
   let(team) { Factory.team }
 
   describe "#initialize" do

--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -5,7 +5,7 @@ Spectator.describe RoleCreate do
 
   mock_client
 
-  let(user_role) { Factory.user_role }
+  let(user_role) { Factory.role_user }
 
   it "validates that required arguments are present" do
     expect(&.validate).to raise_error Program::Error, /Missing required argument/
@@ -30,7 +30,7 @@ Spectator.describe RoleList do
 
   mock_client
 
-  let(roles) { [Factory.system_role, Factory.user_role] }
+  let(roles) { [Factory.role_system, Factory.role_user] }
   let(team) { Factory.team }
   let(cluster) { Factory.cluster }
 
@@ -108,7 +108,7 @@ Spectator.describe RoleUpdate do
   mock_client
 
   let(account) { Factory.account }
-  let(role) { Factory.user_role }
+  let(role) { Factory.role_user }
 
   describe "#validate" do
     it "validates that required arguments are present" do
@@ -144,7 +144,7 @@ Spectator.describe RoleDelete do
   mock_client
 
   let(account) { Factory.account }
-  let(role) { Factory.user_role }
+  let(role) { Factory.role_user }
 
   describe "#validate" do
     it "ensures required arguments are present" do

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -117,7 +117,7 @@ module Factory
       team_id:     "l2gnkxjv3beifk6abkraerv7de",
     }.merge(params)
 
-    CB::Client::Network.new **params
+    CB::Model::Network.new **params
   end
 
   def operation(**params)

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -202,7 +202,7 @@ module Factory
       email:      "test@example.com",
     }.merge(params)
 
-    CB::Client::TeamMember.new **params
+    CB::Model::TeamMember.new **params
   end
 
   def tempkey(**params)

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -20,7 +20,7 @@ module Factory
       size_bytes:  123.to_u64,
     }.merge(params)
 
-    CB::Client::Backup.new **params
+    CB::Model::Backup.new **params
   end
 
   def backup_token_aws(**params)
@@ -28,7 +28,7 @@ module Factory
       type:      "s3",
       repo_path: "/the-path",
       stanza:    "h3zwxm6bafaq3mqbgou5zj56su",
-      aws:       CB::Client::AWSBackrestCredential.new(
+      aws:       CB::Model::AWSBackrestCredential.new(
         s3_key: "key",
         s3_key_secret: "secret",
         s3_token: "token",
@@ -37,7 +37,7 @@ module Factory
       ),
     }.merge(params)
 
-    CB::Client::BackupToken.new **params
+    CB::Model::BackupToken.new **params
   end
 
   def backup_token_azr(**params)
@@ -45,7 +45,7 @@ module Factory
       type:      "azure",
       repo_path: "/",
       stanza:    "h3zwxm6bafaq3mqbgou5zj56su",
-      azure:     CB::Client::AzureBackrestCredential.new(
+      azure:     CB::Model::AzureBackrestCredential.new(
         azure_account: "test_account",
         azure_key: "test_token",
         azure_key_type: "sas",
@@ -53,7 +53,7 @@ module Factory
       ),
     }.merge(params)
 
-    CB::Client::BackupToken.new **params
+    CB::Model::BackupToken.new **params
   end
 
   def cluster(**params)

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -7,7 +7,7 @@ module Factory
       name:  "user",
       email: "user@example.com",
     }.merge(params)
-    CB::Client::Account.new **params
+    CB::Model::Account.new **params
   end
 
   def backup(**params)

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -130,6 +130,35 @@ module Factory
     CB::Model::Operation.new **params
   end
 
+  def plan(**params)
+    params = {
+      id:           "jkon7qbrzzccrgwn346w3niloe",
+      display_name: "Example Plan",
+    }.merge(params)
+
+    CB::Model::Plan.new **params
+  end
+
+  def provider(**params)
+    params = {
+      id:           "xujafqpecfcwpa4rmemogvin7m",
+      display_name: "Example Provider",
+      regions:      [] of CB::Model::Region,
+      plans:        [] of CB::Model::Plan,
+    }.merge(params)
+
+    CB::Model::Provider.new **params
+  end
+
+  def region(**params)
+    params = {
+      id:           "jyhs4gzfszhqpnmmlnneyzodfa",
+      display_name: "Central America 1",
+      location:     "Isla Nublar",
+    }.merge(params)
+    CB::Model::Region.new **params
+  end
+
   def user_role(**params)
     params = {
       account_email: "user@example.com",

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -159,7 +159,17 @@ module Factory
     CB::Model::Region.new **params
   end
 
-  def user_role(**params)
+  def role_system(**params)
+    params = {
+      name:     "application",
+      password: "secret",
+      uri:      URI.parse "postgres://application:secret@example.com:5432/postgres",
+    }.merge(params)
+
+    CB::Model::Role.new **params
+  end
+
+  def role_user(**params)
     params = {
       account_email: "user@example.com",
       name:          "u_mijrfkkuqvhernzfqcbqf7b6me",
@@ -167,17 +177,7 @@ module Factory
       uri:           URI.parse "postgres://u_mijrfkkuqvhernzfqcbqf7b6me:secret@example.com:5432/postgres",
     }.merge(params)
 
-    CB::Client::Role.new **params
-  end
-
-  def system_role(**params)
-    params = {
-      name:     "application",
-      password: "secret",
-      uri:      URI.parse "postgres://application:secret@example.com:5432/postgres",
-    }.merge(params)
-
-    CB::Client::Role.new **params
+    CB::Model::Role.new **params
   end
 
   def team(**params)

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -95,6 +95,18 @@ module Factory
     CB::Model::FirewallRule.new **params
   end
 
+  def log_destination(**params)
+    params = {
+      id:          "pxbcigcufjdqje6drled4rj6p4",
+      host:        "host",
+      port:        2020,
+      template:    "template",
+      description: "logdest descr",
+    }.merge(params)
+
+    CB::Model::LogDestination.new **params
+  end
+
   def network(**params)
     params = {
       cidr4:       "192.168.0.0/24",

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -87,6 +87,14 @@ module Factory
     CB::Model::ClusterStatus.new **params
   end
 
+  def firewall_rule(**params)
+    params = {
+      id:   "shofthj3fzaipie44lt6a5i3de",
+      rule: "1.2.3.0/24",
+    }.merge(params)
+    CB::Model::FirewallRule.new **params
+  end
+
   def network(**params)
     params = {
       cidr4:       "192.168.0.0/24",

--- a/src/cb/backup.cr
+++ b/src/cb/backup.cr
@@ -92,13 +92,13 @@ module CB
       output << "Type:".colorize.bold << "            #{token.type}\n"
       output << "Repo Path:".colorize.bold << "       #{token.repo_path}\n"
       output << "Stanza:".colorize.bold << "          #{token.stanza}\n"
-      if cred.is_a?(Client::AWSBackrestCredential)
+      if cred.is_a?(CB::Model::AWSBackrestCredential)
         output << "S3 Bucket:".colorize.bold << "       #{cred.s3_bucket}\n"
         output << "S3 Key:".colorize.bold << "          #{cred.s3_key}\n"
         output << "S3 Key Secret:".colorize.bold << "   #{cred.s3_key_secret}\n"
         output << "S3 Region:".colorize.bold << "       #{cred.s3_region}\n"
         output << "S3 Token:".colorize.bold << "        #{cred.s3_token}\n"
-      elsif cred.is_a?(Client::AzureBackrestCredential)
+      elsif cred.is_a?(CB::Model::AzureBackrestCredential)
         output << "Azure Account:".colorize.bold << "   #{cred.azure_account}\n"
         output << "Azure Container:".colorize.bold << " #{cred.azure_container}\n"
         output << "Azure Key:".colorize.bold << "       #{cred.azure_key}\n"
@@ -112,7 +112,7 @@ module CB
       output << "[#{token.stanza}]\n"
       output << "repo1-type=#{token.type}\n"
       output << "repo1-path=#{token.repo_path}\n"
-      if cred.is_a?(Client::AWSBackrestCredential)
+      if cred.is_a?(CB::Model::AWSBackrestCredential)
         output << <<-AWS
 repo1-s3-bucket=#{cred.s3_bucket}
 repo1-s3-key=#{cred.s3_key}
@@ -121,7 +121,7 @@ repo1-s3-token=#{cred.s3_token}
 repo1-s3-endpoint=s3.dualstack.#{cred.s3_region}.amazonaws.com
 repo1-s3-region=#{cred.s3_region}
 AWS
-      elsif cred.is_a?(Client::AzureBackrestCredential)
+      elsif cred.is_a?(CB::Model::AzureBackrestCredential)
         output << <<-AZURE
 repo1-azure-account=#{cred.azure_account}
 repo1-azure-container=#{cred.azure_container}

--- a/src/cb/manage_firewall.cr
+++ b/src/cb/manage_firewall.cr
@@ -57,7 +57,7 @@ class CB::ManageFirewall < CB::APIAction
     current_rules.each { |r| output.puts "#{pad}#{r.rule.colorize.t_name}" }
   end
 
-  def remove_rule(rule : Client::FirewallRule)
+  def remove_rule(rule : CB::Model::FirewallRule)
     @client.delete_firewall_rule @network_id, rule.id
     "done".colorize.t_success
   rescue e : Client::Error

--- a/src/cb/models/account.cr
+++ b/src/cb/models/account.cr
@@ -1,0 +1,6 @@
+module CB::Model
+  jrecord Account,
+    id : String,
+    name : String,
+    email : String
+end

--- a/src/cb/models/backup.cr
+++ b/src/cb/models/backup.cr
@@ -1,0 +1,29 @@
+module CB::Model
+  jrecord Backup,
+    name : String,
+    started_at : Time,
+    finished_at : Time,
+    lsn_start : String,
+    lsn_stop : String,
+    size_bytes : UInt64
+
+  jrecord BackupToken,
+    type : String,
+    repo_path : String,
+    stanza : String,
+    aws : AWSBackrestCredential? = nil,
+    azure : AzureBackrestCredential? = nil
+
+  jrecord AWSBackrestCredential,
+    s3_key : String,
+    s3_key_secret : String,
+    s3_token : String,
+    s3_region : String,
+    s3_bucket : String
+
+  jrecord AzureBackrestCredential,
+    azure_account : String,
+    azure_container : String,
+    azure_key : String,
+    azure_key_type : String
+end

--- a/src/cb/models/firewall_rule.cr
+++ b/src/cb/models/firewall_rule.cr
@@ -1,0 +1,5 @@
+module CB::Model
+  jrecord FirewallRule,
+    id : String,
+    rule : String
+end

--- a/src/cb/models/log_destination.cr
+++ b/src/cb/models/log_destination.cr
@@ -1,0 +1,8 @@
+module CB::Model
+  jrecord LogDestination,
+    id : String,
+    host : String,
+    port : Int32,
+    template : String,
+    description : String
+end

--- a/src/cb/models/network.cr
+++ b/src/cb/models/network.cr
@@ -1,0 +1,9 @@
+module CB::Model
+  jrecord Network,
+    cidr4 : String,
+    id : String,
+    name : String,
+    provider_id : String,
+    region_id : String,
+    team_id : String
+end

--- a/src/cb/models/providers.cr
+++ b/src/cb/models/providers.cr
@@ -1,0 +1,15 @@
+module CB::Model
+  jrecord Plan,
+    id : String,
+    display_name : String
+
+  jrecord Provider, id : String,
+    display_name : String,
+    regions : Array(Region),
+    plans : Array(Plan)
+
+  jrecord Region,
+    id : String,
+    display_name : String,
+    location : String
+end

--- a/src/cb/models/role.cr
+++ b/src/cb/models/role.cr
@@ -1,0 +1,8 @@
+module CB::Model
+  jrecord Role,
+    account_id : String? = nil,
+    account_email : String? = nil,
+    name : String = "",
+    password : String? = nil,
+    uri : URI? = nil
+end

--- a/src/cb/models/session.cr
+++ b/src/cb/models/session.cr
@@ -1,0 +1,5 @@
+module CB::Model
+  jrecord Session,
+    id : String,
+    one_time_token : String
+end

--- a/src/cb/models/team_member.cr
+++ b/src/cb/models/team_member.cr
@@ -1,0 +1,9 @@
+module CB::Model
+  # A team member is a association of a bridge user to a bridge team.
+  jrecord TeamMember,
+    id : String,
+    team_id : String,
+    account_id : String,
+    role : String,
+    email : String
+end

--- a/src/cb/network.cr
+++ b/src/cb/network.cr
@@ -9,7 +9,7 @@ module CB
     format_setter format
 
     # Result of API calls.
-    property networks : Array(Client::Network) = [] of Client::Network
+    property networks : Array(CB::Model::Network) = [] of CB::Model::Network
 
     # Flag to indicate whether the output should include a header. This only
     # has an effect when the output format is `table`.

--- a/src/cb/team_member.cr
+++ b/src/cb/team_member.cr
@@ -36,7 +36,7 @@ abstract class CB::TeamMemberAction < CB::APIAction
     members.find { |tm| tm.email == email }
   end
 
-  private def team_member_details(tm : CB::Client::TeamMember) : String
+  private def team_member_details(tm : CB::Model::TeamMember) : String
     String.build do |str|
       str << "Email:     \t" << tm.email.colorize.t_name << '\n'
       str << "Team ID:   \t" << tm.team_id.colorize.t_id << '\n'

--- a/src/client/account.cr
+++ b/src/client/account.cr
@@ -2,15 +2,10 @@ require "./client"
 
 module CB
   class Client
-    jrecord Account,
-      id : String,
-      name : String,
-      email : String
-
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/account/get-account
     def get_account
       resp = get "account"
-      Account.from_json resp.body
+      CB::Model::Account.from_json resp.body
     end
   end
 end

--- a/src/client/backup.cr
+++ b/src/client/backup.cr
@@ -2,44 +2,16 @@ require "./client"
 
 module CB
   class Client
-    jrecord Backup,
-      name : String,
-      started_at : Time,
-      finished_at : Time,
-      lsn_start : String,
-      lsn_stop : String,
-      size_bytes : UInt64
-
     def backup_list(id : Identifier)
       cluster_id = id.eid? ? id.to_s : get_cluster_by_name(id).id
       resp = get "clusters/#{cluster_id}/backups"
-      Array(Backup).from_json resp.body, root: "backups"
+      Array(CB::Model::Backup).from_json resp.body, root: "backups"
     end
-
-    jrecord AWSBackrestCredential,
-      s3_key : String,
-      s3_key_secret : String,
-      s3_token : String,
-      s3_region : String,
-      s3_bucket : String
-
-    jrecord AzureBackrestCredential,
-      azure_account : String,
-      azure_container : String,
-      azure_key : String,
-      azure_key_type : String
-
-    jrecord BackupToken,
-      type : String,
-      repo_path : String,
-      stanza : String,
-      aws : AWSBackrestCredential? = nil,
-      azure : AzureBackrestCredential? = nil
 
     def backup_token(id : Identifier)
       cluster_id = id.eid? ? id.to_s : get_cluster_by_name(id).id
       resp = post "clusters/#{cluster_id}/backup-tokens"
-      BackupToken.from_json resp.body
+      CB::Model::BackupToken.from_json resp.body
     end
 
     def backup_start(id : Identifier)

--- a/src/client/firewall_rule.cr
+++ b/src/client/firewall_rule.cr
@@ -2,8 +2,6 @@ require "./client"
 
 module CB
   class Client
-    jrecord FirewallRule, id : String, rule : String
-
     # Add a firewall rule to a cluster.
     #
     # TODO (abrightwell): Add docs reference.
@@ -23,7 +21,7 @@ module CB
     # TODO (abrightwell): Add docs reference.
     def get_firewall_rules(network_id)
       resp = get "networks/#{network_id}/firewall-rules"
-      Array(FirewallRule).from_json resp.body, root: "firewall_rules"
+      Array(CB::Model::FirewallRule).from_json resp.body, root: "firewall_rules"
     end
   end
 end

--- a/src/client/log_destination.cr
+++ b/src/client/log_destination.cr
@@ -2,19 +2,12 @@ require "./client"
 
 module CB
   class Client
-    jrecord LogDestination,
-      id : String,
-      host : String,
-      port : Int32,
-      template : String,
-      description : String
-
     # List existing loggers for a cluster.
     #
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridloggers/list-loggers
     def get_log_destinations(cluster_id)
       resp = get "clusters/#{cluster_id}/loggers"
-      Array(LogDestination).from_json resp.body, root: "loggers"
+      Array(CB::Model::LogDestination).from_json resp.body, root: "loggers"
     end
 
     # Add a logger to a cluster.

--- a/src/client/network.cr
+++ b/src/client/network.cr
@@ -2,14 +2,6 @@ require "./client"
 
 module CB
   class Client
-    jrecord Network,
-      cidr4 : String,
-      id : String,
-      name : String,
-      provider_id : String,
-      region_id : String,
-      team_id : String
-
     # Get a network by id or name.
     #
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/networksnetworkid
@@ -20,7 +12,7 @@ module CB
 
     def get_network(id : String?)
       resp = get "networks/#{id}"
-      Network.from_json resp.body
+      CB::Model::Network.from_json resp.body
     end
 
     # Get all networks for a team.
@@ -34,7 +26,7 @@ module CB
                get "networks"
              end
 
-      Array(Network).from_json resp.body, root: "networks"
+      Array(CB::Model::Network).from_json resp.body, root: "networks"
     end
 
     private def get_network_by_name(id : Identifier)

--- a/src/client/providers.cr
+++ b/src/client/providers.cr
@@ -2,21 +2,12 @@ require "./client"
 
 module CB
   class Client
-    jrecord Plan, id : String, display_name : String
-
-    jrecord Region, id : String, display_name : String, location : String
-
-    jrecord Provider, id : String,
-      display_name : String,
-      regions : Array(Region),
-      plans : Array(Plan)
-
     # List available providers.
     #
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/providers/list-providers
     def get_providers
       resp = get "providers"
-      Array(Provider).from_json resp.body, root: "providers"
+      Array(CB::Model::Provider).from_json resp.body, root: "providers"
     end
   end
 end

--- a/src/client/role.cr
+++ b/src/client/role.cr
@@ -2,17 +2,10 @@ require "./client"
 
 module CB
   class Client
-    jrecord Role,
-      account_id : String? = nil,
-      account_email : String? = nil,
-      name : String = "",
-      password : String? = nil,
-      uri : URI? = nil
-
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridroles/create-role
     def create_role(cluster_id)
       resp = post "clusters/#{cluster_id}/roles", "{}"
-      Role.from_json resp.body
+      CB::Model::Role.from_json resp.body
     end
 
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrolesrolename/get-role
@@ -24,25 +17,25 @@ module CB
 
     def get_role(cluster_id, role_name)
       resp = get "clusters/#{cluster_id}/roles/#{role_name}"
-      Role.from_json resp.body
+      CB::Model::Role.from_json resp.body
     end
 
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridroles/list-roles
     def list_roles(cluster_id)
       resp = get "clusters/#{cluster_id}/roles"
-      Array(Role).from_json resp.body, root: "roles"
+      Array(CB::Model::Role).from_json resp.body, root: "roles"
     end
 
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrolesrolename/update-role
     def update_role(cluster_id, role_name, ur)
       resp = put "clusters/#{cluster_id}/roles/#{role_name}", ur
-      Role.from_json resp.body
+      CB::Model::Role.from_json resp.body
     end
 
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrolesrolename/delete-role
     def delete_role(cluster_id, role_name)
       resp = delete "clusters/#{cluster_id}/roles/#{role_name}"
-      Role.from_json resp.body
+      CB::Model::Role.from_json resp.body
     end
   end
 end

--- a/src/client/session.cr
+++ b/src/client/session.cr
@@ -1,15 +1,12 @@
 module CB
   class Client
-    jrecord Session,
-      id : String,
-      one_time_token : String
-
-    jrecord SessionCreateParams, generate_one_time_token : Bool
+    jrecord SessionCreateParams,
+      generate_one_time_token : Bool
 
     # https://crunchybridgeapiinternal.docs.apiary.io/#reference/0/sessions/create-session
     def create_session(params : SessionCreateParams)
       resp = post "sessions", params
-      Session.from_json resp.body
+      CB::Model::Session.from_json resp.body
     end
   end
 end

--- a/src/client/team_member.cr
+++ b/src/client/team_member.cr
@@ -2,14 +2,6 @@ require "./client"
 
 module CB
   class Client
-    # A team member is a association of a bridge user to a bridge team.
-    jrecord TeamMember,
-      id : String,
-      team_id : String,
-      account_id : String,
-      role : String,
-      email : String
-
     # Parameters required for adding a user to a team.
     jrecord TeamMemberCreateParams, email : String, role : String
 
@@ -18,7 +10,7 @@ module CB
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembers/create-team-member
     def create_team_member(team_id, params : TeamMemberCreateParams)
       resp = post "teams/#{team_id}/members", params
-      TeamMember.from_json resp.body
+      CB::Model::TeamMember.from_json resp.body
     end
 
     # List the memebers of a team.
@@ -26,7 +18,7 @@ module CB
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembers/list-team-members
     def list_team_members(team_id)
       resp = get "teams/#{team_id}/members"
-      Array(TeamMember).from_json resp.body, root: "team_members"
+      Array(CB::Model::TeamMember).from_json resp.body, root: "team_members"
     end
 
     # Retrieve details about a team member.
@@ -34,7 +26,7 @@ module CB
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembersaccountid/get-team-member
     def get_team_member(team_id, account_id)
       resp = get "teams/#{team_id}/members/#{account_id}"
-      TeamMember.from_json resp.body
+      CB::Model::TeamMember.from_json resp.body
     end
 
     # Update a team member.
@@ -42,7 +34,7 @@ module CB
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembersaccountid/update-team-member
     def update_team_member(team_id, account_id, role)
       resp = put "teams/#{team_id}/members/#{account_id}", {role: role}
-      TeamMember.from_json resp.body
+      CB::Model::TeamMember.from_json resp.body
     end
 
     # Remove a team member from a team.
@@ -50,7 +42,7 @@ module CB
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teamsteamidmembersaccountid/remove-team-member
     def remove_team_member(team_id, account_id)
       resp = delete "teams/#{team_id}/members/#{account_id}"
-      TeamMember.from_json resp.body
+      CB::Model::TeamMember.from_json resp.body
     end
   end
 end


### PR DESCRIPTION
Here we're wrapping up the high level `CB::Model` refactor by moving all of the remaining and relevant models out of `CB::Client` into `CB::Model`.  Much of this is simply a copy/paste of the structs. However, we also take the opportunity to add missing `Factory` methods as well as updating related specs to use the `Factory` over direct instantiation of the models.