### PR TITLE
Add flake for devShells

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+shard.lock linguist-generated
+flake.lock linguist-generated

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679281263,
+        "narHash": "sha256-neMref1GTruSLt1jBgAw+lvGsZj8arQYfdxvSi5yp4Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8276a165b9fa3db1a7a4f29ee29b680e0799b9dc",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-crystal": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679314101,
+        "narHash": "sha256-a+HeIaA5eiJnVfXqXzTMJqOZ1LT/lARDY8MoYJHIp2c=",
+        "owner": "will",
+        "repo": "nixpkgs-crystal",
+        "rev": "cafea11171d5c9ec20abcd5013ed538afa3d4fcb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "will",
+        "repo": "nixpkgs-crystal",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-crystal": "nixpkgs-crystal"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "CrunchyBridge CLI";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs-crystal = {
+      url = "github:will/nixpkgs-crystal";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-crystal, flake-utils }:
+    let
+      systems = (builtins.attrNames nixpkgs-crystal.outputs.packages);
+    in
+    flake-utils.lib.eachSystem systems (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        crystal = nixpkgs-crystal.packages.${system}.crystal;
+      in
+      {
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ crystal pkgs.libssh2 ];
+        };
+
+      }
+    );
+}


### PR DESCRIPTION
This flake adds dev shells for x86 linux and both x86/arm mac development. Right now it's using a crystal flake I made in my own github account, but we can move that to crunchy's nixpkgs once we get that going.

The flake does not provide a build yet for cb, but that should be possible in the future.