### PR TITLE
Add nix default package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ completion.log
 /dist/
 /vendor/
 .envrc
+result

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679281263,
-        "narHash": "sha256-neMref1GTruSLt1jBgAw+lvGsZj8arQYfdxvSi5yp4Q=",
+        "lastModified": 1678875422,
+        "narHash": "sha256-T3o6NcQPwXjxJMn2shz86Chch4ljXgZn746c2caGxd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8276a165b9fa3db1a7a4f29ee29b680e0799b9dc",
+        "rev": "126f49a01de5b7e35a43fd43f891ecf6d3a51459",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679314101,
-        "narHash": "sha256-a+HeIaA5eiJnVfXqXzTMJqOZ1LT/lARDY8MoYJHIp2c=",
+        "lastModified": 1680621422,
+        "narHash": "sha256-y7sHi08QeyLDEOztMIjGJPqVZ+yWIWG4IL2161iTeUw=",
         "owner": "will",
         "repo": "nixpkgs-crystal",
-        "rev": "cafea11171d5c9ec20abcd5013ed538afa3d4fcb",
+        "rev": "cafe263d0ca86beb96c70f61f95c2f36b9531d0c",
         "type": "github"
       },
       "original": {

--- a/shards.nix
+++ b/shards.nix
@@ -1,0 +1,52 @@
+{
+  ameba = {
+    url = "https://github.com/crystal-ameba/ameba.git";
+    rev = "v1.3.1";
+    sha256 = "0qs4x3w0kb5s685ghgj6cnsqbxrjp7iga1racb7d70lr0w2sr7a9";
+  };
+  any_hash = {
+    url = "https://github.com/sija/any_hash.cr.git";
+    rev = "v0.2.5";
+    sha256 = "0qfddwaalcz7f95xbr42cvwh1wzifr5m27lp735fjz2y4xx2c5kj";
+  };
+  backtracer = {
+    url = "https://github.com/sija/backtracer.cr.git";
+    rev = "v1.2.2";
+    sha256 = "1rknyylsi14m7i77x7c3138wdw27i4f6sd78m3srw851p47bwr20";
+  };
+  db = {
+    url = "https://github.com/crystal-lang/crystal-db.git";
+    rev = "v0.11.0";
+    sha256 = "1ylfhpn64p72ywi39niqb179f61z08q4qd4hhjza05z18mdaghl3";
+  };
+  pg = {
+    url = "https://github.com/will/crystal-pg.git";
+    rev = "v0.26.0";
+    sha256 = "04fwbgrlf2nzma0p2c8ki7p8sk113jhziq2al3ivif2lpmhr39fy";
+  };
+  promise = {
+    url = "https://github.com/spider-gazelle/promise.git";
+    rev = "v3.0.0";
+    sha256 = "1pyzxmp7prx3bkzxxdpl7ji0m79y710gnblyl58q4kgxw9srr8fk";
+  };
+  raven = {
+    url = "https://github.com/sija/raven.cr.git";
+    rev = "v1.9.2";
+    sha256 = "1ywh5h98m78cpkjpq9kz0g62flmq2i2lyldha5zc8hdwk6z9q1bi";
+  };
+  spectator = {
+    url = "https://gitlab.com/arctic-fox/spectator.git";
+    rev = "v0.11.3";
+    sha256 = "08mz5mvy64bfb0a6gnb93r0qqipfkz4pgdfxjcb1n1hj9ljnqjpk";
+  };
+  ssh2 = {
+    url = "https://github.com/spider-gazelle/ssh2.cr.git";
+    rev = "v1.5.3";
+    sha256 = "1a9m7df26yp50lxacdp8jjdyx00i33g5dz271zf33bqr9c6kfg8b";
+  };
+  tallboy = {
+    url = "https://github.com/epoch/tallboy.git";
+    rev = "v0.9.3";
+    sha256 = "0s1sc6n8si3krrjb9imv5bazxbd5fl4nkarc3lmjyrvs6c9i56zc";
+  };
+}

--- a/src/cb.cr
+++ b/src/cb.cr
@@ -15,13 +15,13 @@ module CB
   # Release constants.
   BUILD_RELEASE  = {{ flag?(:release) }}
   SHARDS_VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
-  BUILD_DATE     = {{ `date -u +"%Y%m%d%H%M"`.chomp.stringify }}
+  BUILD_SHA      = {{ env("GIT_SHA") || `git describe --match=NeVeRmAtCh --always --dirty 2> /dev/null || echo "unknown sha"`.chomp.stringify }}
   VERSION        = begin
     {% begin %}
       %(#{SHARDS_VERSION}#{"-unrelease" unless BUILD_RELEASE})
     {% end %}
   end
-  VERSION_STR = "cb v#{CB::VERSION} (#{CB::BUILD_DATE})"
+  VERSION_STR = "cb v#{CB::VERSION} (#{CB::BUILD_SHA})"
 end
 
 require "./ext/stdlib_ext"


### PR DESCRIPTION
This changes the build version to remove the date and instead have a git sha, which makes the builds more reproducible.

It also add a default package so you can use cb like:

    $ nix run . -- version
    $ nix run github:crunchydata/bridge-cli\?ref=cafee81 -- version

and after this is merged, just

    $ nix run github:crunchydata/bridge_cli -- version
    $ nix shell github:crunchydata/bridge_cli

etc

Right now the version of crystal the flake this is using is 1.8.0-dev. ~My impression is that~ 1.8.0 will be released ~soon~ on April 12th, and we can switch to that. However were planning on stamping a release version anytime soon, we should probably have that version using crystal 1.7.3 proper
