### PR TITLE
Use updated packaging for crystal

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -16,12 +19,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -32,36 +38,52 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678875422,
-        "narHash": "sha256-T3o6NcQPwXjxJMn2shz86Chch4ljXgZn746c2caGxd8=",
+        "lastModified": 1681753173,
+        "narHash": "sha256-MrGmzZWLUqh2VstoikKLFFIELXm/lsf/G9U9zR96VD4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "126f49a01de5b7e35a43fd43f891ecf6d3a51459",
+        "rev": "0a4206a51b386e5cda731e8ac78d76ad924c7125",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
-    "nixpkgs-crystal": {
+    "nixpkgs-crunchy": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1680621422,
-        "narHash": "sha256-y7sHi08QeyLDEOztMIjGJPqVZ+yWIWG4IL2161iTeUw=",
-        "owner": "will",
-        "repo": "nixpkgs-crystal",
-        "rev": "cafe263d0ca86beb96c70f61f95c2f36b9531d0c",
+        "lastModified": 1682082097,
+        "narHash": "sha256-gUoo6qJqAXoGJksy6Z//WiYuKNF/2s9DNM6kzmMtQLk=",
+        "owner": "crunchydata",
+        "repo": "nixpkgs",
+        "rev": "cafecb73f69150faf33fc99473216f72678bcd31",
         "type": "github"
       },
       "original": {
-        "owner": "will",
-        "repo": "nixpkgs-crystal",
+        "owner": "crunchydata",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681753173,
+        "narHash": "sha256-MrGmzZWLUqh2VstoikKLFFIELXm/lsf/G9U9zR96VD4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0a4206a51b386e5cda731e8ac78d76ad924c7125",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -69,7 +91,37 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-crystal": "nixpkgs-crystal"
+        "nixpkgs-crunchy": "nixpkgs-crunchy"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },


### PR DESCRIPTION
I've made a lot of improvements to the crystal flake I've been working on.

* A function that applies a bunch of defaults to make a crystal package, to remove a bunch of the boilerplate there.
* An "extra wrapped" crystal compiler.

I don't know if there is a more idiomatic nix name for doing this. I was already wrapping the crystal compiler with all the env vars it needs to find llvm, know about openssl, and find the other libraries like pcre2, bohem-gc, etc. However for projects that needed extra libraries, like libssh2, you would need to specify them both in the devshell, as well as when making a package for your program. On top of that, since the compiler wasn't wrapped with these new libraries, `crystal i` wouldn't know about them. It was possible to override the entire crystal derivation with extra buildInputs, but then you'd have to recompile the compiler, which seemed like a waste. So I added a new derivation for crystal that uses the original one as input (which comes wrapped once with the base libraries), and then wrap it again with the extra libraries you need. The end result is that now you only need to say libssh2 in one place, and `crystal i` works. I think it's neat.