### PR TITLE
fix: shorter time period for starting_from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cb upgrade cancel` now only cancels upgrades.
 - `cb maintenance cancel` now only cancels only maintenances.
 - `cb logs` fails without error message.
+- `cb upgrade start --starting-from` now checks that it is in less than 72 hours.
+
 
 ## [3.2.0] - 2023-02-28
 ### Added

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -6,12 +6,22 @@ Spectator.describe CB::UpgradeStart do
   mock_client
 
   let(cluster) { Factory.cluster }
+  describe "#validate" do
+    it "checks required arguments are present" do
+      expect_missing_arg_error
 
-  it "validates that required arguments are present" do
-    expect_missing_arg_error
+      action.cluster_id = cluster.id
+      action.validate.should eq true
+    end
 
-    action.cluster_id = cluster.id
-    action.validate.should eq true
+    it "errors if starting_from is in more than 72 hours" do
+      action.cluster_id = cluster.id
+      action.starting_from = Time.utc + Time::Span.new(hours: 72, seconds: 1)
+
+      expect {
+        action.validate
+      }.to raise_error Program::Error, "'--starting-from' should be in less than 72 hours"
+    end
   end
 
   it "#run prints cluster upgrade started" do
@@ -316,6 +326,17 @@ Spectator.describe CB::UpgradeUpdate do
 
   let(cluster) { Factory.cluster }
   let(team) { Factory.team }
+
+  describe "#validate" do
+    it "errors if starting_from is in more than 72 hours" do
+      action.cluster_id = cluster.id
+      action.starting_from = Time.utc + Time::Span.new(hours: 72, seconds: 1)
+
+      expect {
+        action.validate
+      }.to raise_error Program::Error, "'--starting-from' should be in less than 72 hours"
+    end
+  end
 
   describe "#run" do
     it "does not update maintenance" do

--- a/src/cb/cluster_upgrade.cr
+++ b/src/cb/cluster_upgrade.cr
@@ -28,10 +28,10 @@ abstract class CB::UpgradeAction < CB::Upgrade
     raise Error.new "Must use '--starting-from' or '--now' but not both." if starting_from && now
 
     if now
-      starting_from = Time.utc
+      @starting_from = Time.utc
     end
 
-    raise Error.new "'--starting-from' should be in less than a week" if (start = starting_from) && start > (Time.utc + Time::Span.new(days: 7))
+    raise Error.new "'--starting-from' should be in less than 72 hours" if (start = @starting_from) && start > (Time.utc + Time::Span.new(hours: 72))
     true
   end
 end
@@ -170,10 +170,10 @@ abstract class CB::UpdateUpgradeAction < CB::Upgrade
     end
 
     if now
-      starting_from = Time.utc
+      @starting_from = Time.utc
     end
 
-    raise Error.new "'--starting-from' should be in less than a week" if (start = starting_from) && start > (Time.utc + Time::Span.new(days: 7))
+    raise Error.new "'--starting-from' should be in less than 72 hours" if (start = @starting_from) && start > (Time.utc + Time::Span.new(hours: 72))
     true
   end
 end


### PR DESCRIPTION
Following
https://crunchydata.slack.com/archives/C012GUR4XAT/p1681809181226709, the starting_from parameter should be reduced from 7 days to 72 hours. This is needed as the server is created right away, but not billed to the user.

I don't know if something should be added in the changelog