### PR TITLE
Partially revert 8dd4b5d.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ clean:
 spec: libs deps $(SOURCES)
 	$(CRYSTAL_BIN) tool format --check
 	@if [ "$(TARGET_OS)" == "darwin" ]; then \
-		LIBRARY_PATH=$(STATIC_LIBS_DIR):$(LIBRARY_PATH) $(CRYSTAL_BIN) spec -Dmt_no_expectations --error-trace; \
+		LIBRARY_PATH=$(STATIC_LIBS_DIR) $(CRYSTAL_BIN) spec -Dmt_no_expectations --error-trace; \
 	else \
 		$(CRYSTAL_BIN) spec -Dmt_no_expectations --error-trace; \
 	fi


### PR DESCRIPTION
Here we're partially reverting part of 8dd4b5d. Specifically, we are removing the `LIBRARY_PATH` addition that was made before we had made more progress towards integrating the use of nix dev shells via `flake.nix`.  We've since resolved the issue and it is no longer necessary to include this ENV when running the specs on MacOS.