### PR TITLE
Cross platform forks and replica.

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,3 +1,10 @@
+Layout/TrailingWhitespace:
+  Description: Disallows trailing whitespace.
+  Excluded:
+  # exclude spec files as some expected output might contain trailing
+  # whitespaces.
+  - spec/*/***
+
 Metrics/CyclomaticComplexity:
   Description: Disallows methods with a cyclomatic complexity higher than `MaxComplexity`
   MaxComplexity: 10
@@ -5,11 +12,11 @@ Metrics/CyclomaticComplexity:
   - src/cb/completion.cr
   Enabled: true
   Severity: Convention
-
-Layout/TrailingWhitespace:
-  Description: Disallows trailing whitespace.
-  Excluded:
-  # exclude spec files as some expected output might contain trailing
-  # whitespaces.
-  - spec/*/***
   Enabled: true
+
+# TODO (abrightwell): Disabled as it was unnecessarily noisy and none of the
+# fields being flagged truly needed to be converted at this time. However, it's
+# probably a good idea to come back through and check them again in the near
+# future. Especially if it might improve functionality. 
+Style/QueryBoolMethods:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a pending upgrade respectively.
 
 ### Fixed
+- `cb destroy` completion to include `--confirm`.
 - `cb psql` no longer overrides a users `.psqlrc` with `\x auto` which was
   causing unexpected formatting for some users.
 - `cb info` now returns new cluster states: `resuming`, `suspended`, `suspending`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `cb create --fork` and `cb create --replica` now supports cross platform
+  creation.
 - `cb list` command now accepts `--format`. Supports: `table` and `tree`.
 - `cb list` command now accepts `--team`.
 - `cb maintenance update` and `cb upgrade update` update a pending maintenance
@@ -13,12 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `cb destroy` completion to include `--confirm`.
+- `cb info` now returns new cluster states: `resuming`, `suspended`, `suspending`.
+- `cb logs` fails without error message.
+- `cb maintenance cancel` now only cancels maintenances.
 - `cb psql` no longer overrides a users `.psqlrc` with `\x auto` which was
   causing unexpected formatting for some users.
-- `cb info` now returns new cluster states: `resuming`, `suspended`, `suspending`.
 - `cb upgrade cancel` now only cancels upgrades.
-- `cb maintenance cancel` now only cancels only maintenances.
-- `cb logs` fails without error message.
 - `cb upgrade start --starting-from` now checks that it is in less than 72 hours.
 
 

--- a/spec/cb/cluster_create_spec.cr
+++ b/spec/cb/cluster_create_spec.cr
@@ -25,6 +25,38 @@ Spectator.describe CB::ClusterCreate do
     end
   end
 
+  describe "#pre_validate" do
+    before_each {
+      expect(client).to receive(:get_cluster).and_return(cluster)
+    }
+
+    it "fills in defaults for replica" do
+      expect(&.name).to be_nil
+
+      action.replica = cluster.id
+
+      expect(&.pre_validate).to_not raise_error
+      expect(&.name).to eq "Replica of abc"
+    end
+
+    it "fills in defaults for fork" do
+      expect(&.name).to be_nil
+
+      action.fork = cluster.id
+
+      expect(&.pre_validate).to_not raise_error
+      expect(&.name).to eq "Fork of abc"
+    end
+
+    it "overwrites defaults" do
+      action.fork = cluster.id
+      action.name = "given name"
+
+      expect(&.pre_validate).to_not raise_error
+      expect(&.name).to eq "given name"
+    end
+  end
+
   describe "#at=" do
     sample ["", "hi", "2021-03-06T00:00:00"] do |at|
       it "does not allow invalid values" do
@@ -119,98 +151,6 @@ Spectator.describe CB::ClusterCreate do
       action.call
 
       expect(&.output.to_s).to eq "Created cluster pkdpq6yynjgjbps4otxd7il2u4 \"abc\"\n"
-    end
-  end
-
-  describe "#call - replica" do
-    before_each {
-      expect(client).to receive(:get_cluster).and_return(cluster)
-    }
-
-    it "fills in defaults from the source cluster" do
-      expect(&.name).to be_nil
-      expect(&.platform).to be_nil
-      expect(&.region).to be_nil
-      expect(&.storage).to be_nil
-      expect(&.plan).to be_nil
-      expect(&.network).to be_nil
-
-      action.fork = cluster.id
-      expect(&.pre_validate).to_not raise_error
-
-      expect(&.name).to eq "Fork of abc"
-      expect(&.platform).to eq "aws"
-      expect(&.region).to eq "us-east-2"
-      expect(&.storage).to eq 1234
-      expect(&.plan).to eq "memory-4"
-      expect(&.network).to eq cluster.network_id
-
-      expect(&.validate).to be_true
-    end
-
-    it "does not overwrite values given with defaults from source cluster" do
-      action.fork = cluster.id
-      action.name = "given name"
-      action.platform = "gcp"
-      action.region = "centralus"
-      action.plan = "cpu-100"
-      action.storage = 4321
-      action.network = "cywdcbebozfczpsnl2ha643m3e"
-
-      expect(&.pre_validate).to_not raise_error
-
-      expect(&.name).to eq "given name"
-      expect(&.platform).to eq "gcp"
-      expect(&.region).to eq "centralus"
-      expect(&.plan).to eq "cpu-100"
-      expect(&.storage).to eq 4321
-      expect(&.network).to eq "cywdcbebozfczpsnl2ha643m3e"
-
-      expect(&.validate).to be_true
-    end
-  end
-
-  describe "#call - fork" do
-    before_each {
-      expect(client).to receive(:get_cluster).and_return(cluster)
-    }
-
-    it "fills in defaults from the source cluster" do
-      expect(&.name).to be_nil
-      expect(&.platform).to be_nil
-      expect(&.region).to be_nil
-      expect(&.storage).to be_nil
-      expect(&.plan).to be_nil
-
-      action.fork = cluster.id
-      expect(&.pre_validate).to_not raise_error
-
-      expect(&.name).to eq "Fork of abc"
-      expect(&.platform).to eq "aws"
-      expect(&.region).to eq "us-east-2"
-      expect(&.storage).to eq 1234
-      expect(&.plan).to eq "memory-4"
-
-      expect(&.validate).to be_true
-    end
-
-    it "does not overwrite values given with defaults from source cluster" do
-      action.fork = cluster.id
-      action.name = "given name"
-      action.platform = "gcp"
-      action.region = "centralus"
-      action.plan = "cpu-100"
-      action.storage = 4321
-
-      expect(&.pre_validate).to_not raise_error
-
-      expect(&.name).to eq "given name"
-      expect(&.platform).to eq "gcp"
-      expect(&.region).to eq "centralus"
-      expect(&.plan).to eq "cpu-100"
-      expect(&.storage).to eq 4321
-
-      expect(&.validate).to be_true
     end
   end
 end

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -303,6 +303,17 @@ Spectator.describe CB::Completion do
     expect(result).to eq [] of String
   end
 
+  it "list" do
+    result = parse("cb list ")
+    expect(result).to have_option "--team"
+
+    result = parse("cb list --team ")
+    expect(result).to eq expected_team_suggestion
+
+    result = parse("cb list --team abc ")
+    expect(result).to eq [] of String
+  end
+
   it "logdest" do
     result = parse("cb logdest ")
     expect(result).to have_option "list"

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -100,7 +100,7 @@ Spectator.describe CB::Completion do
 
   provided command: "cb " { expect(result).to have /^login/ }
 
-  sample %w[info rename destroy logs suspend resume].each do |cmd|
+  sample %w[info rename logs suspend resume].each do |cmd|
     provided command: "cb #{cmd} " { expect(result).to eq expected_cluster_suggestion }
     provided command: "cb #{cmd} abc " { expect(result).to be_empty }
   end
@@ -259,6 +259,17 @@ Spectator.describe CB::Completion do
     result.should_not be_empty
     expect(result).to_not have_option "--version"
     expect(result).to_not have_option "-v"
+  end
+
+  it "destroy" do
+    result = parse("cb destroy ")
+    expect(result).to eq expected_cluster_suggestion
+
+    result = parse("cb destroy abc ")
+    expect(result).to have_option "--confirm"
+
+    result = parse("cb destroy abc --confirm ")
+    result.should be_empty
   end
 
   it "firewall" do

--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -160,7 +160,7 @@ module CB
       raise Error.new "Invalid #{field.colorize.bold}: '#{value.to_s.colorize.red}'"
     end
 
-    private def check_required_args
+    private def check_required_args(&)
       missing = [] of String
       yield missing
       unless missing.empty?

--- a/src/cb/cluster_create.cr
+++ b/src/cb/cluster_create.cr
@@ -15,7 +15,7 @@ class CB::ClusterCreate < CB::APIAction
   property at : Time?
 
   def pre_validate
-    if (id = fork || replica)
+    if id = fork || replica
       source = client.get_cluster id
       @name ||= "#{fork ? "Fork" : "Replica"} of #{source.name}"
     else

--- a/src/cb/cluster_create.cr
+++ b/src/cb/cluster_create.cr
@@ -17,16 +17,23 @@ class CB::ClusterCreate < CB::APIAction
   def pre_validate
     if (id = fork || replica)
       source = client.get_cluster id
-
       @name ||= "#{fork ? "Fork" : "Replica"} of #{source.name}"
-      @platform ||= source.provider_id
-      @region ||= source.region_id
-      @storage ||= source.storage
-      @plan ||= source.plan_id
-      @network ||= source.network_id
     else
       @storage ||= 100
       @name ||= "Cluster #{Time.utc.to_s("%F %H_%M_%S")}"
+    end
+  end
+
+  def validate
+    pre_validate
+
+    check_required_args do |missing|
+      missing << "name" unless name
+      missing << "platform" unless platform
+      missing << "plan" unless plan
+      missing << "region" unless region
+      missing << "storage" unless storage
+      missing << "team" unless team || fork || replica
     end
   end
 
@@ -34,39 +41,34 @@ class CB::ClusterCreate < CB::APIAction
     validate
 
     params = {
-      "is_ha":               @ha,
-      "name":                @name,
-      "plan_id":             @plan,
-      "provider_id":         @platform,
-      "postgres_version_id": @postgres_version,
-      "region_id":           @region,
-      "storage":             @storage,
-      "team_id":             @team,
-      "network_id":          @network,
+      name:        @name.to_s,
+      network_id:  @network,
+      plan_id:     @plan,
+      provider_id: @platform,
+      region_id:   @region,
     }
 
     cluster = if fork
-                @client.fork_cluster self
+                @client.create_fork CB::Client::ForkCreateParams.new(**params.merge(
+                  cluster_id: @fork.to_s,
+                  is_ha: @ha,
+                  storage: @storage,
+                  target_time: @at,
+                ))
               elsif replica
-                @client.replicate_cluster self
+                @client.create_replica CB::Client::ReplicaCreateParams.new(**params.merge(
+                  cluster_id: @replica.to_s,
+                ))
               else
-                @client.create_cluster params
+                @client.create_cluster CB::Client::ClusterCreateParams.new(**params.merge(
+                  is_ha: @ha,
+                  storage: @storage,
+                  team_id: @team.to_s,
+                  postgres_version_id: @postgres_version,
+                ))
               end
 
     @output << "Created cluster #{cluster.id.colorize.t_id} \"#{cluster.name.colorize.t_name}\"\n"
-  end
-
-  def validate
-    pre_validate
-    check_required_args do |missing|
-      missing << "ha" if ha.nil?
-      missing << "name" unless name
-      missing << "plan" unless plan
-      missing << "platform" unless platform
-      missing << "region" unless region
-      missing << "storage" unless storage
-      missing << "team" unless team || fork || replica
-    end
   end
 
   def at=(str : String)

--- a/src/cb/cluster_info.cr
+++ b/src/cb/cluster_info.cr
@@ -19,7 +19,7 @@ class CB::ClusterInfo < CB::APIAction
 
     details = {
       "state"              => cluster_status.state,
-      "host"               => c.host,
+      "host"               => c.host.empty? ? "Not available" : c.host,
       "created"            => c.created_at.to_rfc3339,
       "plan"               => "#{c.plan_id} (#{format(c.memory)}GiB ram, #{format(c.cpu)}vCPU)",
       "version"            => c.major_version,
@@ -34,7 +34,7 @@ class CB::ClusterInfo < CB::APIAction
       details["source cluster"] = source
     end
 
-    details["network"] = c.network_id if c.network_id
+    details["network"] = c.network_id ? c.network_id.to_s : "Not available"
 
     pad = (details.keys.map(&.size).max || 8) + 2
     details.each do |k, v|
@@ -42,13 +42,15 @@ class CB::ClusterInfo < CB::APIAction
       output << v << "\n"
     end
 
-    firewall_rules = client.get_firewall_rules c.network_id
-    output << "firewall".rjust(pad).colorize.bold << ": "
-    if firewall_rules.empty?
-      output << "no rules\n"
-    else
-      output << "allowed cidrs".colorize.underline << "\n"
+    if c.network_id
+      firewall_rules = client.get_firewall_rules c.network_id
+      output << "firewall".rjust(pad).colorize.bold << ": "
+      if firewall_rules.empty?
+        output << "no rules\n"
+      else
+        output << "allowed cidrs".colorize.underline << "\n"
+      end
+      firewall_rules.each { |fr| output << " "*(pad + 4) << fr.rule << "\n" }
     end
-    firewall_rules.each { |fr| output << " "*(pad + 4) << fr.rule << "\n" }
   end
 end

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -54,6 +54,8 @@ class CB::Completion
         firewall
       when "logdest"
         logdest
+      when "list"
+        list_clusters
       when "maintenance"
         maintenance
       when "network"
@@ -239,6 +241,16 @@ class CB::Completion
     if last_arg?(flag)
       cluster_suggestions
     end
+  end
+
+  def list_clusters
+    if last_arg?("--team")
+      return team_suggestions
+    end
+
+    suggest = [] of String
+    suggest << "--team\tteam id" unless has_full_flag? :team
+    suggest
   end
 
   def firewall

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -44,10 +44,12 @@ class CB::Completion
       top_level
     else
       case args.first
-      when "info", "destroy", "rename", "logs", "suspend", "resume"
+      when "info", "rename", "logs", "suspend", "resume"
         single_cluster_suggestion
       when "create"
         create
+      when "destroy"
+        destroy_cluster
       when "detach"
         detach
       when "firewall"
@@ -241,6 +243,14 @@ class CB::Completion
     if last_arg?(flag)
       cluster_suggestions
     end
+  end
+
+  def destroy_cluster
+    return cluster_suggestions if @args.size == 2
+
+    suggest = [] of String
+    suggest << "--confirm\tconfirm cluster #{@args.first}" unless has_full_flag? :confirm
+    suggest
   end
 
   def list_clusters

--- a/src/cb/network.cr
+++ b/src/cb/network.cr
@@ -15,7 +15,7 @@ module CB
     # has an effect when the output format is `table`.
     property no_header : Bool = false
 
-    def run
+    def run(&)
       validate
 
       yield

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -158,10 +158,10 @@ op = OptionParser.new do |parser|
     parser.examples = <<-EXAMPLES
       Create a new cluster.
       $ cb create --name <NAME> --platform <NAME> --region <NAME> --plan <NAME>
-      
+
       Create a fork.
       $ cb create --fork <ID>
-      
+
       Create a read-replica.
       $ cb create --replica <ID>
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -137,8 +137,8 @@ op = OptionParser.new do |parser|
     create = set_action ClusterCreate
     parser.banner = <<-EOB
       cb create <--platform|-p> <--region|-r> <--plan> <--team|-t> [--size|-s] [--name|-n] [--version|-v] [--ha] [--network]
-             cb create --fork ID [--at] [--platform|-p] [--region|-r] [--plan] [--size|-s] [--name|-n] [--ha] [--network]
-             cb create --replica ID [--platform|-p] [--region|-r] [--plan] [--name|-n] [--network]
+          cb create --fork ID [--at] [--platform|-p] [--region|-r] [--plan] [--size|-s] [--name|-n] [--ha] [--network]
+          cb create --replica ID [--platform|-p] [--region|-r] [--plan] [--name|-n] [--network]
     EOB
 
     parser.on("--ha <true|false>", "High Availability (default: false)") { |arg| create.ha = arg }
@@ -154,6 +154,21 @@ op = OptionParser.new do |parser|
     parser.on("--replica ID", "Choose source cluster for read-replica") { |arg| create.replica = arg }
     parser.on("--fork ID", "Choose source cluster for fork") { |arg| create.fork = arg }
     parser.on("--at TIME", "Recovery point-in-time in RFC3339 (default: now)") { |arg| create.at = arg }
+
+    parser.examples = <<-EXAMPLES
+      Create a new cluster.
+      $ cb create --name <NAME> --platform <NAME> --region <NAME> --plan <NAME>
+      
+      Create a fork.
+      $ cb create --fork <ID>
+      
+      Create a read-replica.
+      $ cb create --replica <ID>
+
+      Create a cross platform fork/replica.
+      $ cb create --fork <ID> --platform <NAME> --region <NAME> --plan <NAME>
+      $ cb create --replica <ID> --platform <NAME> --region <NAME> --plan <NAME>
+    EXAMPLES
   end
 
   # Cluster Upgrade
@@ -235,8 +250,10 @@ op = OptionParser.new do |parser|
   end
 
   parser.on("destroy", "Destroy a cluster") do
-    parser.banner = "cb destroy <cluster id>"
+    parser.banner = "cb destroy <cluster id> [--confirm]"
     destroy = set_action ClusterDestroy
+
+    parser.on("--confirm", "Confirm cluster restart") { destroy.confirmed = true }
 
     positional_args destroy.cluster_id
   end

--- a/src/ext/stdlib_ext.cr
+++ b/src/ext/stdlib_ext.cr
@@ -28,7 +28,7 @@ Colorize.on_tty_only!
 
 class IO
   # no-op for non-file descriptor IOs, e.g. specs
-  def noecho
+  def noecho(&)
     yield
   end
 end

--- a/src/models/cluster.cr
+++ b/src/models/cluster.cr
@@ -22,7 +22,7 @@ module CB::Model
 
     property name : String
 
-    property network_id : String
+    property network_id : String?
 
     property plan_id : String
 
@@ -49,7 +49,7 @@ module CB::Model
                    @maintenance_window_start = nil,
                    @major_version = 0,
                    @memory = 0,
-                   @network_id = "",
+                   @network_id = nil,
                    @plan_id = "",
                    @provider_id = "",
                    @region_id = "",


### PR DESCRIPTION
Here we're updating `cb create --fork` and `cb create --replica` to
support cross platform creation. Previously, this was not possible as
the fork and replica client requests were always defaulting to the
target/primary cluster's platform, region and plan. Now, it is possible
to create a fork or replica in another platform in the same way it is
that a standalone cluster is created.

For instance, to create an AWS based fork in GCP:

```
$ cb create --fork <ID> --platform gcp --region uswest-1 --plan
standard-8
```

If `--name` is omitted, then the value will default to `Fork of <name>`
where `<name>` is the name of the source cluster.  The same is true for
replicas, expept that it will `Replica of <name>`.

This also allows for the creation of forks and replicas across regions
within the same platform as well. Though, it still requires the full
qualification of specifying the target `--platform` and `--plan`.
Future improvements on this might be possible to simply allow the user
to only specify the `--region`. However, for now it seems prudent to
simply keep this current requirement as it helps to ensure (through
completion) that the any region or plan specified is correct/available
for a specific platform.
