### PR TITLE
Update `flake.nix`.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "ameba-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1677051617,
+        "narHash": "sha256-coZU3cufQgSCid10zEvmHG7ddLbZhnrvl9ffw4Y6h74=",
+        "owner": "crystal-ameba",
+        "repo": "ameba",
+        "rev": "6f05df4006e82ba05a55dcfa831f6dbdb3b0191d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "crystal-ameba",
+        "ref": "v1.4.2",
+        "repo": "ameba",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -38,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681753173,
-        "narHash": "sha256-MrGmzZWLUqh2VstoikKLFFIELXm/lsf/G9U9zR96VD4=",
+        "lastModified": 1682109806,
+        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a4206a51b386e5cda731e8ac78d76ad924c7125",
+        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
         "type": "github"
       },
       "original": {
@@ -54,15 +71,16 @@
     },
     "nixpkgs-crunchy": {
       "inputs": {
+        "ameba-src": "ameba-src",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1682082097,
-        "narHash": "sha256-gUoo6qJqAXoGJksy6Z//WiYuKNF/2s9DNM6kzmMtQLk=",
+        "lastModified": 1682499061,
+        "narHash": "sha256-QREk35hQaEFxCJUFx2t4C/WPOYZAvIcnwqLiy4zI10c=",
         "owner": "crunchydata",
         "repo": "nixpkgs",
-        "rev": "cafecb73f69150faf33fc99473216f72678bcd31",
+        "rev": "cafe26edb06e59ceb835038631d741354ec5c064",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,9 @@
         pkgs = nixpkgs.legacyPackages.${system};
         crystal-pkgs = nixpkgs-crunchy.packages.${system};
 
+        ameba = crystal-pkgs.ameba;
         crystal = crystal-pkgs.crystal;
-        crystalWrapped = crystal-pkgs.extraWrapped.override {
+        crystalWrapped = crystal-pkgs.crystalWrapped.override {
           buildInputs = [ pkgs.libssh2 ];
         };
 
@@ -32,7 +33,7 @@
         };
 
         devShells.default = pkgs.mkShell {
-          buildInputs = [ crystalWrapped c2n ];
+          buildInputs = [ crystalWrapped c2n ameba ];
         };
 
       }


### PR DESCRIPTION
Updates flake.nix to incorporate upstream changes to `crunchy-nixpkgs`. As well, we add `ameba` to the `devShell`.