### PR TITLE
Use the ha dedicated endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- High availability changes with `cb upgrade start` must be made without any other changes to the cluster.
+
 ## [3.4.0] - 2023-08-14
 ### Added
 - `cb config-param` command to manage supported cluster configuration

--- a/spec/cb/completion_spec.cr
+++ b/spec/cb/completion_spec.cr
@@ -965,6 +965,11 @@ Spectator.describe CB::Completion do
     result = parse("cb upgrade start --ha true ")
     expect(result).to have_option "--cluster"
     expect(result).to_not have_option "--ha"
+    expect(result).to_not have_option "--storage"
+
+    result = parse("cb upgrade start --cluster abc --version 15 ")
+    expect(result).to_not have_option "--ha"
+    expect(result).to have_option "--plan"
 
     # cb upgrade cancel
     result = parse("cb upgrade c")

--- a/spec/factory.cr
+++ b/spec/factory.cr
@@ -134,7 +134,7 @@ module Factory
     CB::Model::Network.new **params
   end
 
-  def operation(**params)
+  def operation(**params) : CB::Model::Operation
     params = {
       flavor:        CB::Model::Operation::Flavor::Resize,
       state:         CB::Model::Operation::State::InProgress,

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -1079,7 +1079,14 @@ class CB::Completion
     suggest << "--help\tshow help" if args.size == 3
     suggest << "--cluster\tcluster id" unless has_full_flag? :cluster
     suggest << "--confirm\tconfirm upgrade" unless has_full_flag? :confirm
-    suggest << "--ha\thigh availability" unless has_full_flag? :ha
+
+    return suggest if has_full_flag? :ha
+
+    upgrade_flags = %i[plan storage starting_from now version]
+    if upgrade_flags.none? { |flag| has_full_flag? flag }
+      suggest << "--ha\thigh availability"
+    end
+
     suggest << "--plan\tplan" unless has_full_flag? :plan
     suggest << "--storage\tsize in GiB" unless has_full_flag? :storage
     suggest << "--starting-from\tstarting time of upgrade. (RFC3339 format)" unless has_full_flag?(:starting_from) || has_full_flag?(:now)

--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -198,6 +198,22 @@ module CB
       CB::Model::Cluster.from_json resp.body
     end
 
+    # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridactionsdisable-ha/disable-high-availability
+    def disable_ha(id : Identifier) : CB::Model::Operation?
+      resp = put "clusters/#{id}/actions/disable-ha"
+      json = JSON.parse(resp.body)
+      return CB::Model::Operation.from_json resp.body if (flavor = json["flavor"]?) && !flavor.as_s.empty?
+      nil
+    end
+
+    # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridactionsenable-ha/enable-high-availability
+    def enable_ha(id : Identifier) : CB::Model::Operation?
+      resp = put "clusters/#{id}/actions/enable-ha"
+      json = JSON.parse(resp.body)
+      return CB::Model::Operation.from_json resp.body if (flavor = json["flavor"]?) && !flavor.as_s.empty?
+      nil
+    end
+
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridrestart/restart-cluster
     def restart_cluster(id, service : String)
       resp = put "clusters/#{id}/actions/restart", {service: service}


### PR DESCRIPTION
This also prevents the following usage:

```
cb upgrade startr --ha --storage 150
```


This needs https://github.com/CrunchyData/priv-all-cloud-owl/pull/2234 to be deployed