### PR TITLE
Escape team name in `psql` prompt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Credentials validation for `cb login` input.
 
+### Fixed
+- `cb psql` escape single-quotes in prompt for team name.
+
 ## [3.3.2] - 2023-05-10
 ### Fixed
 - Operation::State `replaying_wal` parse issue.

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -74,9 +74,22 @@ module CB
       path.to_s
     end
 
+    private def escape(str) : String
+      String.build do |build|
+        str.each_char do |char|
+          case char
+          when '\''
+            build << "\\'"
+          else
+            build << char
+          end
+        end
+      end
+    end
+
     private def build_psqlrc(c, team_name) : String
       psqlpromptname = String.build do |s|
-        s << "%[%033[32m%]#{team_name}%[%033m%]" << "/" if team_name
+        s << "%[%033[32m%]#{escape(team_name.to_s)}%[%033m%]" << "/" if team_name
         s << "%[%033[36m%]#{c.name}%[%033m%]"
       end
 


### PR DESCRIPTION
Recently, Bridge moved to treating personal teams as regular teams. As a result of that change, personal teams were renamed to `<first name>'s Team`, e.g. `Adam's Team`. Unfortunately, however, the `'` was not being properly escaped in the `PROMPT1` defined in `cb psql` command. As a quick fix to this, we're simply adding a function to escape all single-quotes in the team name before setting the prompt.