### PR TITLE
nix: add builds for aarch64-linux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -109,11 +109,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1683720464,
-        "narHash": "sha256-ixnSeIrvUAXPZEdod1ZB1VA4KFoSpq8qudJLJhIS2pU=",
+        "lastModified": 1684754550,
+        "narHash": "sha256-YE5S6OsHFyMW+ygq4u8/CHgiDj5yyRTI8kL0T4Ncdvc=",
         "owner": "crunchydata",
         "repo": "nixpkgs",
-        "rev": "cafeaeffaf84d2a0d119b163af684f9f38891e69",
+        "rev": "cafeac874ac0547f855f40737be35b63110a7704",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I recently added crystal compilers in our crunchydata/nixpkgs repo, so just by updating cb's flake.lock we should get all builds for aarch64-linux

```bash
[will@nixos:~]$ nix shell github:crunchydata/bridge-cli/aarch64-linux

[will@nixos:~]$ file $(which cb)
/nix/store/zk8244vdw1iljk68gf0wxx05vl7fimbd-cb-3.4.0-dev/bin/cb: 
ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/jxjy8r4k8pf7v0hasi37qgva9va81kj2-glibc-2.37-8/lib/ld-linux-aarch64.so.1, for GNU/Linux 3.10.0, not stripped

[will@nixos:~]$ uname -a
Linux nixos 6.1.28 #1-NixOS SMP Thu May 11 14:04:52 UTC 2023 aarch64 GNU/Linux

[will@nixos:~]$ cb version
cb v3.4.0-dev (cafe9de)
```