### PR TITLE
Update README with new login details.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cb config-param` command to manage supported cluster configuration
   parameters. Supports `get`, `list-supported`, `reset` and `set`.
 
+### Changed
+- `cb login` now uses a browser login flow. If direct use of an `API_KEY` is
+  necessary then it must be set via the `CB_API_KEY` environment variable. 
+
 ### Fixed
 - `cb create --fork` and `cb create --replica` input validation when using
   `--network`.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,21 @@ A CLI for Crunchy Bridge with very good tab completion.
 
 ## Getting started
 
-First get your `application ID` and `application secret` from https://www.crunchybridge.com/account
+First login to your Crunchy Bridge account by running `cb login`.
 
-Then run `cb login` to register the CLI with your Crunchy Bridge account.
+```
+$ cb login
+Press any key to open a browser to login or q to exit:
+Waiting for login... done
+Logged in as user@example.com
+```
+
+If you'd prefer to use an API key then you can create one for your
+[account](https://crunchybridge.com/account/api-keys) and set the `CB_API_KEY`
+environment variable.
+
+**Note:** If the `CB_API_KEY` environment variable is set, then `cb login` will
+not work until it is unset.
 
 ## Usage
 


### PR DESCRIPTION
Updates the README file with the new `login` process. To also include usage of an API Key via the `CB_API_KEY` env.