### PR TITLE
Set `X-Parent-Request-Id` header.

### DIFF
--- a/src/cb/action.cr
+++ b/src/cb/action.cr
@@ -203,6 +203,10 @@ module CB
     property client : Client
 
     def initialize(@client, @input = STDIN, @output = STDOUT)
+      # Set the parent request id header. This is so that all requests related
+      # to a specific action can be grouped together for logging and debugging
+      # purposes.
+      @client.headers["X-Parent-Request-Id"] = UUID.random.to_s
     end
 
     abstract def run


### PR DESCRIPTION
Recently the API added support for a `X-Parent-Request-Id` header. This is so it is more apparent that when an a action is taken that requires multiple requests to complete that the multiple requests can be grouped/identified. This is meant to assist in potential debugging and troubleshooting efforts.

So, here we take advantage of this new feature and by setting it when an `APIAction` is initialized so that it will be included on all API requests made by the action.