### PR TITLE
Fix input validation on `cb create [--fork | --replica]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cb config-param` command to manage supported cluster configuration
   parameters. Supports `get`, `list-supported`, `reset` and `set`.
 
+### Fixed
+- `cb network` command completion suggestions.
+
+
 ## [3.3.3] - 2023-05-18
 ### Added
 - Credentials validation for `cb login` input.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameters. Supports `get`, `list-supported`, `reset` and `set`.
 
 ### Fixed
+- `cb create --fork` and `cb create --replica` input validation when using
+  `--network`.
 - `cb network` command completion suggestions.
-
 
 ## [3.3.3] - 2023-05-18
 ### Added

--- a/src/cb/cluster_create.cr
+++ b/src/cb/cluster_create.cr
@@ -15,6 +15,9 @@ class CB::ClusterCreate < CB::APIAction
   property at : Time?
 
   def pre_validate
+    raise Error.new "Cannot use both '--fork' and '--replica' at the same time." if fork && replica
+    raise Error.new "Cannot use '--network' with '--platform' or '--region'." if network && (platform || region)
+
     if id = fork || replica
       source = client.get_cluster id
       @name ||= "#{fork ? "Fork" : "Replica"} of #{source.name}"
@@ -29,10 +32,9 @@ class CB::ClusterCreate < CB::APIAction
 
     check_required_args do |missing|
       missing << "name" unless name
-      missing << "platform" unless platform
-      missing << "plan" unless plan
-      missing << "region" unless region
-      missing << "storage" unless storage
+      missing << "platform" unless replica || platform || network
+      missing << "plan" unless replica || plan || platform
+      missing << "region" unless replica || region || network
       missing << "team" unless team || fork || replica
     end
   end

--- a/src/cb/completion.cr
+++ b/src/cb/completion.cr
@@ -555,7 +555,7 @@ class CB::Completion
       network_list
     else
       [
-        "info\ndetailed network information",
+        "info\tdetailed network information",
         "list\tlist available networks",
       ]
     end


### PR DESCRIPTION
It was found that input validation was failing when creating a fork or
replica using the `--network` option. Specifically, the following error
was being returned:

```
error: Missing required arguments: platform, plan, region, storage
```

This is because when specifying a network none of these items are
required. Most importantly the platform and region are not allowed. This
was a minor oversight when allowing cross-region replicas was first
implemented.  Here we simply fix that issue and if `--network` is given
then we do not require the platform or region as well.