### PR TITLE
Specify `order_field` parameter in cluster and team lists

### DIFF
--- a/src/client/cluster.cr
+++ b/src/client/cluster.cr
@@ -22,7 +22,7 @@ module CB
     end
 
     def get_clusters(team_id)
-      resp = get "clusters?team_id=#{team_id}"
+      resp = get "clusters?order_field=name&team_id=#{team_id}"
       Array(CB::Model::Cluster).from_json resp.body, root: "clusters"
     end
 

--- a/src/client/team.cr
+++ b/src/client/team.cr
@@ -14,7 +14,7 @@ module CB
     #
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/teams/list-teams
     def get_teams
-      resp = get "teams"
+      resp = get "teams?order_field=name"
       Array(CB::Model::Team).from_json resp.body, root: "teams"
     end
 


### PR DESCRIPTION
The cluster and team list endpoints are exceptional in that unlike every
other endpoint, they order on `name` by default instead of `id`. This
is probably fine, but it'd be sort of nice to try and get all list
endpoints behaving the same way by default, so medium term I'm kind of
hoping I can change the default on cluster and team.

Reading cb code I wasn't totally able to determine whether it relies on
the default name ordering or not, but here, futureproof anyway by just
making sure to send an explicit `order_field=name` to these two
endpoints so they're always guaranteed to get today's ordering back.