### PR TITLE
specs: add look_like matcher

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -16,20 +16,6 @@ Naming/AccessorMethodName:
   Enabled: true
   Severity: Convention
 
-# Problems found: 23
-# Run `ameba --only Layout/TrailingWhitespace` for details
-Layout/TrailingWhitespace:
-  Description: Disallows trailing whitespace
-  Excluded:
-  - spec/cb/network_spec.cr
-  - spec/cb/cluster_upgrade_spec.cr
-  - spec/cb/role_spec.cr
-  - spec/cb/cluster_list_spec.cr
-  - spec/cb/team_spec.cr
-  - spec/cb/config_param_spec.cr
-  Enabled: true
-  Severity: Convention
-
 # Problems found: 11
 # Run `ameba --only Naming/QueryBoolMethods` for details
 Naming/QueryBoolMethods:

--- a/spec/cb/cluster_list_spec.cr
+++ b/spec/cb/cluster_list_spec.cr
@@ -27,12 +27,12 @@ Spectator.describe CB::List do
       action.call
 
       expected = <<-EXPECTED
-        ID           Name         Team       
-        abc          my cluster   Test Team  
-        replica-id   my replica   Test Team  \n
+        ID           Name         Team
+        abc          my cluster   Test Team
+        replica-id   my replica   Test Team
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs tree format" do
@@ -52,10 +52,10 @@ Spectator.describe CB::List do
       expected = <<-EXPECTED
       Test Team
       └── my cluster (abc)
-          └── my replica (replica-id)\n
+          └── my replica (replica-id)
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end

--- a/spec/cb/cluster_upgrade_spec.cr
+++ b/spec/cb/cluster_upgrade_spec.cr
@@ -43,7 +43,7 @@ Spectator.describe CB::UpgradeStart do
 
       action.call
 
-      expect(&.output.to_s).to eq "  Cluster #{action.cluster_id} upgrade started.\n"
+      expect(&.output).to look_like "  Cluster #{action.cluster_id} upgrade started."
     end
   end
 end
@@ -71,7 +71,7 @@ Spectator.describe CB::UpgradeStart do
 
     action.call
 
-    expect(&.output.to_s).to eq "  Enabling high availability on cluster #{action.cluster_id}.\n"
+    expect(&.output).to look_like "  Enabling high availability on cluster #{action.cluster_id}."
   end
 end
 
@@ -100,14 +100,14 @@ Spectator.describe CB::UpgradeStart do
     action.ha = true
     action.call
 
-    expect(&.output.to_s).to eq "  High availability already enabled on cluster #{action.cluster_id}.\n"
+    expect(&.output).to look_like "  High availability already enabled on cluster #{action.cluster_id}."
   end
 
   it "reports if it's already disabled" do
     action.ha = false
     action.call
 
-    expect(&.output.to_s).to eq "  High availability already disabled on cluster #{action.cluster_id}.\n"
+    expect(&.output).to look_like "  High availability already disabled on cluster #{action.cluster_id}."
   end
 end
 
@@ -134,7 +134,7 @@ Spectator.describe CB::UpgradeStart do
 
     action.call
 
-    expect(&.output.to_s).to eq "  Disabling high availability on cluster #{action.cluster_id}.\n"
+    expect(&.output).to look_like "  Disabling high availability on cluster #{action.cluster_id}."
   end
 end
 
@@ -158,7 +158,7 @@ Spectator.describe CB::UpgradeStart do
 
     action.call
 
-    expect(&.output.to_s).to eq "  Operation not recognized: CB::Model::Operation(@flavor=CB::Model::Operation::Flavor::Resize, @state=CB::Model::Operation::State::InProgress, @starting_from=nil)\n"
+    expect(&.output).to look_like "  Operation not recognized: CB::Model::Operation(@flavor=CB::Model::Operation::Flavor::Resize, @state=CB::Model::Operation::State::InProgress, @starting_from=nil)"
   end
 end
 
@@ -189,7 +189,7 @@ Spectator.describe CB::MaintenanceCreate do
 
       action.call
 
-      expect(&.output.to_s).to eq "  Maintenance created for Cluster #{action.cluster_id}.\n"
+      expect(&.output).to look_like "  Maintenance created for Cluster #{action.cluster_id}."
     end
   end
 end
@@ -220,11 +220,11 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      operations:           no operations in progress               
-      maintenance window:   no window set. Default to: 00:00-23:59  \n
+      operations:           no operations in progress
+      maintenance window:   no window set. Default to: 00:00-23:59
     EXPECTED
 
-    expect(&.output.to_s).to eq expected
+    expect(&.output).to look_like expected
   end
 
   it "#run display ha operation by default" do
@@ -238,11 +238,11 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      ha change:            in progress                             
-      maintenance window:   no window set. Default to: 00:00-23:59  \n
+      ha change:            in progress
+      maintenance window:   no window set. Default to: 00:00-23:59
     EXPECTED
 
-    expect(&.output.to_s).to eq expected
+    expect(&.output).to look_like expected
   end
 
   it "#run display failover windown starting if there is one" do
@@ -256,11 +256,11 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      resize:               in progress (Starting from: 2022-01-01T00:00:00Z)  
-      maintenance window:   no window set. Default to: 00:00-23:59             \n
+      resize:               in progress (Starting from: 2022-01-01T00:00:00Z)
+      maintenance window:   no window set. Default to: 00:00-23:59
     EXPECTED
 
-    expect(&.output.to_s).to eq expected
+    expect(&.output).to look_like expected
   end
 
   it "#run filter ha operation if told so" do
@@ -275,11 +275,11 @@ Spectator.describe CB::UpgradeStatus do
 
     expected = <<-EXPECTED
     #{team.name}/#{cluster.name}
-      operations:           no operations in progress               
-      maintenance window:   no window set. Default to: 00:00-23:59  \n
+      operations:           no operations in progress
+      maintenance window:   no window set. Default to: 00:00-23:59
     EXPECTED
 
-    expect(&.output.to_s).to eq expected
+    expect(&.output).to look_like expected
   end
 end
 
@@ -309,10 +309,10 @@ Spectator.describe CB::UpgradeCancel do
       expected = <<-EXPECTED
       #{team.name}/#{cluster.name}
         there is no pending operation.
-        use 'cb maintenance cancel' to cancel the pending maintenance.\n
+        use 'cb maintenance cancel' to cancel the pending maintenance.
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "cancel other operations" do
@@ -327,10 +327,10 @@ Spectator.describe CB::UpgradeCancel do
 
       expected = <<-EXPECTED
       #{team.name}/#{cluster.name}
-        resize operation cancelled\n
+        resize operation cancelled
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end
@@ -362,10 +362,10 @@ Spectator.describe CB::MaintenanceCancel do
       expected = <<-EXPECTED
       #{team.name}/#{cluster.name}
         there is no pending maintenance.
-        use 'cb upgrade cancel' to cancel the pending resize.\n
+        use 'cb upgrade cancel' to cancel the pending resize.
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "cancels maintenance" do
@@ -380,10 +380,10 @@ Spectator.describe CB::MaintenanceCancel do
 
       expected = <<-EXPECTED
       #{team.name}/#{cluster.name}
-        maintenance operation cancelled\n
+        maintenance operation cancelled
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end
@@ -416,10 +416,10 @@ Spectator.describe CB::MaintenanceUpdate do
       expected = <<-EXPECTED
       #{team.name}/#{cluster.name}
         there is no pending maintenance.
-        use 'cb upgrade update' to update the pending resize.\n
+        use 'cb upgrade update' to update the pending resize.
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "updates maintenance" do
@@ -436,10 +436,10 @@ Spectator.describe CB::MaintenanceUpdate do
 
       expected = <<-EXPECTED
       #{team.name}/#{cluster.name}
-        maintenance updated.\n
+        maintenance updated.
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end
@@ -477,10 +477,10 @@ Spectator.describe CB::UpgradeUpdate do
       expected = <<-EXPECTED
       #{team.name}/#{cluster.name}
         there is no pending upgrade.
-        use 'cb maintenance update' to update the pending maintenance.\n
+        use 'cb maintenance update' to update the pending maintenance.
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "updates resize" do
@@ -497,10 +497,10 @@ Spectator.describe CB::UpgradeUpdate do
 
       expected = <<-EXPECTED
       #{team.name}/#{cluster.name}
-        upgrade updated.\n
+        upgrade updated.
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end

--- a/spec/cb/config_param_spec.cr
+++ b/spec/cb/config_param_spec.cr
@@ -31,11 +31,11 @@ Spectator.describe ConfigurationParameterGet do
       action.call
 
       expected = <<-EXPECTED
-        Component   Name              Value  
-        postgres    max_connections   100    \n
+        Component   Name              Value
+        postgres    max_connections   100
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "lists no parameters when none are set" do
@@ -44,10 +44,10 @@ Spectator.describe ConfigurationParameterGet do
       action.call
 
       expected = <<-EXPECTED
-        Component   Name   Value  \n
+        Component   Name   Value
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs default format" do
@@ -56,12 +56,12 @@ Spectator.describe ConfigurationParameterGet do
       action.call
 
       expected = <<-EXPECTED
-        Component   Name              Value  
-        postgres    max_connections   100    
-        postgres    max_connections   100    \n
+        Component   Name              Value
+        postgres    max_connections   100
+        postgres    max_connections   100
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs json format" do
@@ -82,10 +82,10 @@ Spectator.describe ConfigurationParameterGet do
             "value": "100"
           }
         ]
-      }\n
+      }
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end
@@ -115,12 +115,12 @@ Spectator.describe ConfigurationParameterListSupported do
       action.call
 
       expected = <<-EXPECTED
-        Component   Name                Requires Restart  
-        postgres    max_connections     no                
-        pgbouncer   default_pool_size   no                \n
+        Component   Name                Requires Restart
+        postgres    max_connections     no
+        pgbouncer   default_pool_size   no
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs specific component" do
@@ -128,11 +128,11 @@ Spectator.describe ConfigurationParameterListSupported do
       action.call
 
       expected = <<-EXPECTED
-        Component   Name              Requires Restart  
-        postgres    max_connections   no                \n
+        Component   Name              Requires Restart
+        postgres    max_connections   no
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end
@@ -157,11 +157,11 @@ Spectator.describe ConfigurationParameterSet do
       action.call
 
       expected = <<-EXPECTED
-        Component   Name              Value  
-        postgres    max_connections   100    \n
+        Component   Name              Value
+        postgres    max_connections   100
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs json format" do
@@ -182,10 +182,10 @@ Spectator.describe ConfigurationParameterSet do
               "value": "100"
             }
           ]
-        }\n
+        }
         EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end
@@ -211,22 +211,22 @@ Spectator.describe ConfigurationParameterReset do
       action.call
 
       expected = <<-EXPECTED
-        Component   Name              Value  
-        postgres    max_connections   100    \n
+        Component   Name              Value
+        postgres    max_connections   100
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs default" do
       action.call
 
       expected = <<-EXPECTED
-        Component   Name              Value  
-        postgres    max_connections   100    \n
+        Component   Name              Value
+        postgres    max_connections   100
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs json format" do
@@ -245,10 +245,10 @@ Spectator.describe ConfigurationParameterReset do
               "value": "100"
             }
           ]
-        }\n
+        }
         EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end

--- a/spec/cb/network_spec.cr
+++ b/spec/cb/network_spec.cr
@@ -49,11 +49,11 @@ Spectator.describe NetworkList do
       action.call
 
       expected = <<-EXPECTED
-        ID                           Team                         Name              CIDR4            Provider   Region     
-        oap3kavluvgm7cwtzgaaixzfoi   l2gnkxjv3beifk6abkraerv7de   Default Network   192.168.0.0/24   aws        us-east-1  \n
+        ID                           Team                         Name              CIDR4            Provider   Region
+        oap3kavluvgm7cwtzgaaixzfoi   l2gnkxjv3beifk6abkraerv7de   Default Network   192.168.0.0/24   aws        us-east-1
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs table without header" do
@@ -61,10 +61,10 @@ Spectator.describe NetworkList do
       action.call
 
       expected = <<-EXPECTED
-        oap3kavluvgm7cwtzgaaixzfoi   l2gnkxjv3beifk6abkraerv7de   Default Network   192.168.0.0/24   aws   us-east-1  \n
+        oap3kavluvgm7cwtzgaaixzfoi   l2gnkxjv3beifk6abkraerv7de   Default Network   192.168.0.0/24   aws   us-east-1
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs json" do
@@ -83,10 +83,10 @@ Spectator.describe NetworkList do
             "team_id": "l2gnkxjv3beifk6abkraerv7de"
           }
         ]
-      }\n
+      }
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end

--- a/spec/cb/role_spec.cr
+++ b/spec/cb/role_spec.cr
@@ -21,7 +21,7 @@ Spectator.describe RoleCreate do
 
     action.call
 
-    expect(&.output.to_s).to eq "Role #{user_role.name} created on cluster #{action.cluster_id}.\n"
+    expect(&.output).to look_like "Role #{user_role.name} created on cluster #{action.cluster_id}."
   end
 end
 
@@ -56,12 +56,12 @@ Spectator.describe RoleList do
       action.call
 
       expected = <<-EXPECTED
-        Role                           Account           
-        application                    system            
-        u_mijrfkkuqvhernzfqcbqf7b6me   user@example.com  \n
+        Role                           Account
+        application                    system
+        u_mijrfkkuqvhernzfqcbqf7b6me   user@example.com
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs table without header" do
@@ -69,11 +69,11 @@ Spectator.describe RoleList do
       action.call
 
       expected = <<-EXPECTED
-        application                    system            
-        u_mijrfkkuqvhernzfqcbqf7b6me   user@example.com  \n
+        application                    system
+        u_mijrfkkuqvhernzfqcbqf7b6me   user@example.com
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
 
     it "outputs json" do
@@ -94,10 +94,10 @@ Spectator.describe RoleList do
              "account": "user@example.com"
            }
          ]
-       }\n
+       }
        EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end
@@ -133,7 +133,7 @@ Spectator.describe RoleUpdate do
       expect(client).to receive(:get_account).and_return account
       expect(client).to receive(:update_role).and_return role
       action.call
-      expect(&.output.to_s).to eq "Role #{action.role} updated on cluster #{action.cluster_id}.\n"
+      expect(&.output).to look_like "Role #{action.role} updated on cluster #{action.cluster_id}."
     end
   end
 end
@@ -171,7 +171,7 @@ Spectator.describe RoleDelete do
 
       action.call
 
-      expect(&.output.to_s).to eq "Role #{action.role} deleted from cluster #{action.cluster_id}.\n"
+      expect(&.output).to look_like "Role #{action.role} deleted from cluster #{action.cluster_id}."
     end
   end
 end

--- a/spec/cb/team_spec.cr
+++ b/spec/cb/team_spec.cr
@@ -16,14 +16,14 @@ Spectator.describe TeamInfo do
       action.call
 
       expected = <<-EXPECTED
-        ID:              l2gnkxjv3beifk6abkraerv7de  
-        Name:            Test Team                   
-        Role:            Admin                       
-        Billing Email:   test@example.com            
-        Enforce SSO:     disabled                    \n
+        ID:              l2gnkxjv3beifk6abkraerv7de
+        Name:            Test Team
+        Role:            Admin
+        Billing Email:   test@example.com
+        Enforce SSO:     disabled
       EXPECTED
 
-      expect(&.output.to_s).to eq expected
+      expect(&.output).to look_like expected
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,7 +1,6 @@
 require "../src/cb"
-require "./support/*"
-# require "spec"
 require "spectator"
+require "./support/*"
 require "spectator/should"
 
 include CB

--- a/spec/support/look_like_matcher.cr
+++ b/spec/support/look_like_matcher.cr
@@ -1,0 +1,22 @@
+struct LookLikeMatcher(ExpectedType) < Spectator::Matchers::ValueMatcher(ExpectedType)
+  def description : String
+    "is visually equal to #{expected.label}"
+  end
+
+  private def match?(actual : Spectator::Expression(T)) : Bool forall T
+    strip(actual.value.to_s) == strip(expected.value)
+  end
+
+  private def strip(str) : String
+    str.to_s.strip.gsub(/\s+\n/, '\n')
+  end
+
+  private def failure_message(actual : Spectator::Expression(T)) : String forall T
+    "#{actual.label} isn't visually equal to #{expected.label}"
+  end
+end
+
+macro look_like(expected)
+  %value = ::Spectator::Value.new({{expected}}, {{expected.stringify}})
+  LookLikeMatcher.new(%value)
+end


### PR DESCRIPTION
This makes it so the whitespace can be trimmed from the spec files and not break the tests, and also remove the exception from ameba