### PR TITLE
Update `cb create` to require `--region` with `gcp` networks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - High availability changes with `cb upgrade start` must be made without any other changes to the cluster.
+- Validation on `cb create` using `--network` for `gcp` based networks.
 
 ## [3.4.0] - 2023-08-14
 ### Added

--- a/spec/cb/cluster_create_spec.cr
+++ b/spec/cb/cluster_create_spec.cr
@@ -152,5 +152,30 @@ Spectator.describe CB::ClusterCreate do
 
       expect(&.output.to_s).to eq "Created cluster pkdpq6yynjgjbps4otxd7il2u4 \"abc\"\n"
     end
+
+    it "raises error when no region given with gcp network" do
+      network = Factory.network(provider_id: "gcp")
+
+      action.network = network.id
+      action.plan = "hobby-2"
+      action.region = nil
+      action.team = team.id
+
+      expect(client).to receive(:get_network).and_return network
+      expect(&.call).to raise_error(CB::Program::Error, "Must also specify '--region' for a 'gcp' based network.")
+    end
+
+    it "raises error when region or provider given with non-gcp network" do
+      network = Factory.network
+
+      action.network = network.id
+      action.plan = "hobby-2"
+      action.platform = "aws"
+      action.region = "us-east-1"
+      action.team = team.id
+
+      expect(client).to receive(:get_network).and_return network
+      expect(&.call).to raise_error(CB::Program::Error, "Cannot use '--network' with '--platform' or '--region'")
+    end
   end
 end


### PR DESCRIPTION
When creating a cluster in a specific network, there are a few rules that apply that differ between the supported providers.

The execption is specifically with `gcp` based networks. GCP networks are `global` meaning they are not bound to a specific `region`. Therefore it is necessary to specify a region when creating a new cluster of any type with a target network that is `gcp` based.

All other cases (`aws` and `azr`) a provider and region must not be given along with a target network. As this information is attached/bound to the network.