### PR TITLE
Changed `cb uri` and `cb psql` to default to `user` role.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `cb uri` and `cb psql` now default to `user` role when `--role` is not
+  specified. The value `default` for `--role` has been removed and is no longer
+  valid.
 
 ## [3.4.1] - 2023-12-13
 ### Added
@@ -15,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where a default browser is not available
 
 ### Fixed
-- High availability changes with `cb upgrade start` must be made without any other changes to the cluster.
+- High availability changes with `cb upgrade start` must be made without any
+  other changes to the cluster.
 - Validation on `cb create` using `--network` for `gcp` based networks.
 
 ## [3.4.0] - 2023-08-14

--- a/spec/cb/cluster_uri_spec.cr
+++ b/spec/cb/cluster_uri_spec.cr
@@ -6,14 +6,13 @@ Spectator.describe CB::ClusterURI do
 
   mock_client
 
-  let(account) { Factory.account }
   let(cluster) { Factory.cluster }
   let(role) { Factory.role_user }
 
   describe "#initialize" do
-    it "ensures 'default' if role not specified" do
+    it "ensures 'user' if role not specified" do
       action.cluster_id = cluster.id
-      expect(&.role.to_s).to eq "default"
+      expect(&.role.to_s).to eq "user"
     end
   end
 
@@ -31,8 +30,7 @@ Spectator.describe CB::ClusterURI do
       action.cluster_id = cluster.id
       action.role = "user"
 
-      expect(client).to receive(:get_account).and_return(account)
-      expect(client).to receive(:get_role).and_return(role)
+      expect(client).to receive(:create_role).and_return(role)
 
       action.call
 
@@ -49,8 +47,7 @@ Spectator.describe CB::ClusterURI do
       action.port = 5431
       action.role = "user"
 
-      expect(client).to receive(:get_account).and_return(account)
-      expect(client).to receive(:get_role).and_return(role)
+      expect(client).to receive(:create_role).and_return(role)
 
       action.call
 

--- a/spec/cb/psql_spec.cr
+++ b/spec/cb/psql_spec.cr
@@ -15,9 +15,9 @@ Spectator.describe CB::Psql do
   let(team) { Factory.team }
 
   describe "#initialize" do
-    it "ensures 'default' if role not specified" do
+    it "ensures 'user' if role not specified" do
       action.cluster_id = cluster.id
-      expect(&.role.to_s).to eq "default"
+      expect(&.role.to_s).to eq "user"
     end
   end
 
@@ -51,7 +51,7 @@ Spectator.describe CB::Psql do
       action.cluster_id = cluster.id
 
       expect(client).to receive(:get_cluster).and_return(cluster)
-      expect(client).to receive(:get_role).and_return(role)
+      expect(client).to receive(:create_role).and_return(role)
       expect(client).to receive(:get_team).and_return(team)
 
       action.call

--- a/spec/cb/types_spec.cr
+++ b/spec/cb/types_spec.cr
@@ -4,8 +4,8 @@ include CB
 Spectator.describe CB::Role do
   describe "#initialize" do
     subject { described_class }
-    it "creates default" do
-      expect(&.new.name).to eq "default"
+    it "creates default as 'user'" do
+      expect(&.new.name).to eq "user"
     end
 
     sample CB::Role::VALID_CLUSTER_ROLES do |name|

--- a/src/cb/cluster_uri.cr
+++ b/src/cb/cluster_uri.cr
@@ -15,12 +15,12 @@ class CB::ClusterURI < CB::APIAction
   def run
     validate
 
-    if @role == "user"
-      @role = Role.new "u_#{client.get_account.id}"
-    end
+    role = if @role == "user"
+             client.create_role(@cluster_id[:cluster])
+           else
+             client.get_role(@cluster_id[:cluster], @role.to_s)
+           end
 
-    # Fetch the role.
-    role = client.get_role(@cluster_id[:cluster], @role.to_s)
     uri = role.uri
     raise Error.new "There is no URI available for this cluster." unless uri
 

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -29,11 +29,12 @@ module CB
 
       c = client.get_cluster cluster_id[:cluster]
 
-      if @role == "user"
-        @role = Role.new "u_#{client.get_account.id}"
-      end
+      uri = if @role == "user"
+              client.create_role(cluster_id[:cluster]).uri
+            else
+              client.get_role(cluster_id[:cluster], @role.to_s).uri
+            end
 
-      uri = client.get_role(cluster_id[:cluster], @role.to_s).uri
       raise Error.new "null uri" if uri.nil?
 
       database.tap { |db| uri.path = db if db }

--- a/src/cb/types.cr
+++ b/src/cb/types.cr
@@ -2,7 +2,7 @@ module CB
   struct Role
     getter name : String
 
-    VALID_CLUSTER_ROLES = Set{"application", "default", "postgres", "user"}
+    VALID_CLUSTER_ROLES = Set{"application", "postgres", "user"}
 
     private INVALID_ROLE_MESSAGE = "invalid role: '%s'. Must be one of: #{VALID_CLUSTER_ROLES.join ", "}"
 
@@ -10,7 +10,7 @@ module CB
       @name == other
     end
 
-    def initialize(@name : String = "default")
+    def initialize(@name : String = "user")
       raise Program::Error.new INVALID_ROLE_MESSAGE % @name unless valid?
     end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -113,7 +113,7 @@ op = OptionParser.new do |parser|
 
     parser.on("--database DATABASE", "Database name (default: postgres)") { |arg| uri.database = arg }
     parser.on("--port PORT", "Port number (default: 5432)") { |arg| uri.port = arg }
-    parser.on("--role NAME", "Role name (default: default)") { |arg| uri.role = CB::Role.new arg }
+    parser.on("--role NAME", "Role name (default: user)") { |arg| uri.role = CB::Role.new arg }
     positional_args uri.cluster_id
   end
 


### PR DESCRIPTION
Previously, the default for these commands when `--role` was not specified was `default`. This role name directly maps to `postgres` and is going to be deprecated and ultimately removed from the API as the redundancy is confusing and unnecessary. So here, we are removing it as an option as well as reducing the default role privilege to the lowest level. If elevated privileges are necessary then they need to be explicitly requested with the `--role` flag on each.