### PR TITLE
Fix `cb uri` and `cb psql` by cluster name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `cb uri` and `cb psql` with cluster name regression.
 
 ## [3.4.2] - 2024-01-05
 ### Changed

--- a/src/client/role.cr
+++ b/src/client/role.cr
@@ -3,6 +3,12 @@ require "./client"
 module CB
   class Client
     # https://crunchybridgeapi.docs.apiary.io/#reference/0/clustersclusteridroles/create-role
+    def create_role(cluster_id : Identifier)
+      return create_role(cluster_id.to_s) if cluster_id.eid?
+      c = get_cluster_by_name(cluster_id)
+      create_role(c.id)
+    end
+
     def create_role(cluster_id)
       resp = post "clusters/#{cluster_id}/roles", "{}"
       CB::Model::Role.from_json resp.body


### PR DESCRIPTION
A regression that prevented using the cluster name with the commands was introduced in v3.4.2. These changes fix that issue.