### PR TITLE
Fix `Open.can_open_browser?` for linux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `cb login` failure on linux systems when checking for default browser.
 
 ## [3.4.3] - 2024-01-10
 ### Fixed

--- a/src/lib/open.cr
+++ b/src/lib/open.cr
@@ -12,8 +12,11 @@ module CB::Lib
       {% if flag?(:darwin) %}
         true
       {% elsif flag?(:linux) %}
-        Process.run("command", ["-v", "xdg-settings", "get", "default-web-browser"]).success?
-        # Process.run("command -v #{OPEN_COMMAND}").success?
+        begin
+          Process.run("xdg-settings", ["get", "default-web-browser"]).success?
+        rescue IO::Error
+          false
+        end
       {% else %}
         false
       {% end %}


### PR DESCRIPTION
It was reported in #151 that when attempting to execute `cb login` on a linux based system that `cb` was returning an error for the `command` command.

Regardless of why this command was not found is not necessarily relevant as the underlying calls should be robust enough to tolerate a missing command to open a browser. For instance, even the `xdg-settings` command would have resulted in a command not found and therefore an `IO::Error` being raised for 'headless' systems.

Here we fix this by simply wrapping the call out to these commands with a `begin/rescue` block and on failure return `false`.  This will ensure that login can continue by presenting just the login url with the requisite session intent information that can be copy pasted to a browser on the host system.