### PR TITLE
Add `cb psql` query menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cb psql` now provides a builtin menu of commonly useful queries.
 
 ## [3.4.4] - 2024-01-23
 ### Fixed

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -1,5 +1,6 @@
 require "./action"
 require "./dirs"
+require "./query_menu/*"
 
 module CB
   class Psql < APIAction
@@ -100,6 +101,8 @@ module CB
       File.open(psqlrc.path, "a") do |f|
         f.puts "\\set ON_ERROR_ROLLBACK interactive"
         f.puts "\\set PROMPT1 '#{psqlpromptname}/%[%033[33;1m%]%x%x%x%[%033[0m%]%[%033[1m%]%/%[%033[0m%]%R%# '"
+        f.puts QueryMenu::Menu.new.render(cluster: c)
+        f.puts "\\echo 'Use #{":menu".colorize.bold} to list available queries.'"
       end
 
       psqlrc.path.to_s

--- a/src/cb/query_menu/menu.psql.ecr
+++ b/src/cb/query_menu/menu.psql.ecr
@@ -1,0 +1,32 @@
+<%- option : Int32 = 1 %>
+<%- @queries.each do |category, queries| -%>
+\echo <%= "#{category.colorize.bold}" %>
+<%- queries.each do |query| -%>
+    \echo '  <%= "#{option} \u2013 #{query.label}" %>'
+    <%- option += 1 -%>
+<%- end -%>
+<%- end -%>
+\echo
+\prompt 'Type choice and press <%= "<Enter>".colorize.bold %> (<%= "q".colorize.bold %> to quit): ' choice
+\echo
+
+<%- option = 1 %>
+SELECT CASE
+<%- @queries.each_value do |queries| -%>
+<%- queries.each do |query| %>
+WHEN :'choice'::text = '<%= option %>' THEN
+'\i `echo <%= query.path %>`'
+'\echo'
+'\i <%= @path %>'
+<%- option += 1 -%>
+<%- end -%>
+<%- end -%>
+WHEN :'choice'::text = 'q'
+THEN '\echo Quitting!'
+ELSE
+'\echo <%= "Error:".colorize.red.bold %> Unknown option! Try again.'
+'\echo'
+'\i <%= @path %>'
+END AS action \gset
+
+:action

--- a/src/cb/query_menu/queries.cr
+++ b/src/cb/query_menu/queries.cr
@@ -1,0 +1,118 @@
+require "./query"
+
+module CB::QueryMenu
+  # Here we define the builtin queries that are included when using the `:menu`
+  # command in `psql`.
+  #
+  # Each query MUST do the following:
+  #   * Extend `CB::QueryMenu::Query`
+  #   * Define a `Metadata` annotation that includes the `label` and `category`
+  #     for the query.
+  #   * Embed the SQL for the query. This is done using the `embed_sql` macro.
+  #
+  # Example:
+  # ```
+  # @[Metadata(label: "Example query label", category: Category.new("Example", 1))]
+  # struct Foo < Query
+  #   ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/example.sql")
+  # end
+  # ```
+
+  #
+  # Cache
+  #
+
+  @[Metadata(label: "Cache and index hit rates", category: CATEGORY_CACHE)]
+  struct CacheHitRates < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/cache_hit_rates.sql")
+  end
+
+  #
+  # Connection Management
+  #
+
+  @[Metadata(label: "Connection count by state", category: CATEGORY_CONNECTION_MANAGEMENT)]
+  struct ConnectionManagementCountByStates < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/connection_management_count_by_state.sql")
+  end
+
+  @[Metadata(label: "Connection count by user and application", category: CATEGORY_CONNECTION_MANAGEMENT)]
+  struct ConnectionManagementCountByUser < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/connection_management_count_by_user_and_application.sql")
+  end
+
+  #
+  # Extensions Queries
+  #
+
+  @[Metadata(label: "Available extensions", category: CATEGORY_EXTENSIONS)]
+  struct AvailableExtensions < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/extensions_available.sql")
+  end
+
+  @[Metadata(label: "Installed extensions", category: CATEGORY_EXTENSIONS)]
+  struct InstalledExtensions < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/extensions_installed.sql")
+  end
+
+  #
+  # Index Queries
+  #
+
+  @[Metadata(label: "Duplicate indexes", category: CATEGORY_INDEXES)]
+  struct IndexesDuplicates < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/indexes_duplicates.sql")
+  end
+
+  @[Metadata(label: "List of indexes", category: CATEGORY_INDEXES)]
+  struct IndexesList < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/indexes_list.sql")
+  end
+
+  @[Metadata(label: "Unused indexes", category: CATEGORY_INDEXES)]
+  struct IndexesUnused < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/indexes_unused.sql")
+  end
+
+  #
+  # Locks Queries
+  #
+
+  @[Metadata(label: "Blocking queries", category: CATEGORY_LOCKS)]
+  struct LocksBlockingQueries < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/locks_blocking_queries.sql")
+  end
+
+  #
+  # Query Performance Queries
+  #
+
+  @[Metadata(label: "Queries consuming the most system time", category: CATEGORY_QUERY_PERFORMANCE)]
+  struct MostConsumingQueries < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/query_performance_most_consuming_system_time.sql")
+  end
+
+  @[Metadata(label: "Queries running over 1 minute", category: CATEGORY_QUERY_PERFORMANCE)]
+  struct OverOneMinuteQueries < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/query_performance_over_one_minute.sql")
+  end
+
+  @[Metadata(label: "Slowest average queries", category: CATEGORY_QUERY_PERFORMANCE)]
+  struct SlowestAverageQueries < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/query_performance_slowest_average.sql")
+  end
+
+  #
+  # Size Information Queries
+  #
+
+  @[Metadata(label: "Database sizes", category: CATEGORY_SIZE_INFORMATION)]
+  struct DatabaseSize < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/size_information_database_size.sql")
+  end
+
+  @[Metadata(label: "Table sizes", category: CATEGORY_SIZE_INFORMATION)]
+  struct TableSize < Query
+    ::CB::QueryMenu.embed_sql("#{__DIR__}/sql/size_information_table_size.sql")
+  end
+end

--- a/src/cb/query_menu/query.cr
+++ b/src/cb/query_menu/query.cr
@@ -1,0 +1,89 @@
+require "base64"
+
+module CB::QueryMenu
+  # Metadata annoation for a query.
+  #
+  # A `Query` must have a `label` and `category` field defined using this
+  # annotation.
+  annotation Metadata; end
+
+  # Category for a query, this is used for grouping and order queries in the
+  # query menu.
+  struct Category
+    # The name of the category.
+    getter name : String
+
+    # The order that the category appears in the query menu.
+    getter order : Int8
+
+    def initialize(@name = "", @order = -1); end
+  end
+
+  # Query Categories.
+  CATEGORY_CACHE                 = Category.new name: "Cache", order: 1
+  CATEGORY_CONNECTION_MANAGEMENT = Category.new name: "Connection Management", order: 4
+  CATEGORY_EXTENSIONS            = Category.new name: "Extensions", order: 7
+  CATEGORY_INDEXES               = Category.new name: "Indexes", order: 5
+  CATEGORY_LOCKS                 = Category.new name: "Locks", order: 6
+  CATEGORY_QUERY_PERFORMANCE     = Category.new name: "Query Performance", order: 3
+  CATEGORY_SIZE_INFORMATION      = Category.new name: "Size Information", order: 2
+
+  @[Metadata(label: "", category: Category.new)]
+  abstract struct Query
+    getter dirname : String
+
+    def initialize(@dirname); end
+
+    def path
+      File.join(dirname, sql_filename)
+    end
+
+    # Write the query to file.
+    def write
+      File.open(path, "w") { |file| file << Base64.decode_string(sql) }
+    end
+
+    def self.all
+      {{
+        Query.subclasses.map do |query|
+          ann = query.annotation(Metadata)
+          raise "#{query} is missing Metadata annotation" unless ann
+          query
+        end
+      }}
+    end
+
+    # The category of the query. This value is defined by setting the `category`
+    # field in the `Metadata` annotation.
+    def category : Category
+      {% if @type.annotation(Metadata)[:category] %}
+        {{@type.annotation(Metadata)[:category]}}
+      {% else %}
+        {{raise "#{@type} must have a category."}}
+      {% end %}
+    end
+
+    # The label of the query. This value is define by setting the `label` field
+    # in the `Metadata` annotation.
+    def label : String
+      {% if @type.annotation(Metadata)[:label] %}
+        {{ @type.annotation(Metadata)[:label] }}
+      {% else %}
+        {{raise "#{@type} must have a label."}}
+      {% end %}
+    end
+
+    abstract def sql
+    abstract def sql_filename
+  end
+
+  macro embed_sql(path)
+    def sql
+      {{ run("../../tools/embed_base64.cr", path).stringify }}
+    end
+
+    def sql_filename
+      File.basename {{path}}
+    end
+  end
+end

--- a/src/cb/query_menu/query_menu.cr
+++ b/src/cb/query_menu/query_menu.cr
@@ -1,0 +1,32 @@
+require "ecr"
+require "file_utils"
+
+require "./query"
+
+module CB::QueryMenu
+  class Menu
+    private property queries : Hash(String, Array(Query)) = Hash(String, Array(Query)).new([] of Query)
+    private property path : String = ""
+
+    def render(cluster : CB::Model::Cluster) : String
+      temp_dir = "/tmp/crunchy/cli/#{cluster.name}-#{cluster.id}-queries"
+      FileUtils.mkdir_p(temp_dir) unless File.exists? temp_dir
+
+      # Aggregate all queries and group them by category in alphabetical order.
+      @queries = Query.all.map(&.new(temp_dir))
+        .sort_by!(&.category.order)
+        .group_by(&.category.name)
+
+      # Write the queries to the filesystem.
+      @queries.each_value { |queries| queries.each(&.write) }
+
+      # Render the menu file.
+      @path = File.join(temp_dir, "menu.psql")
+      query_menu = File.open(@path, mode: "w") do |menu|
+        menu << ECR.render __DIR__ + "/menu.psql.ecr"
+      end
+
+      "\\set menu '\\\\i #{query_menu.path} '"
+    end
+  end
+end

--- a/src/cb/query_menu/sql/cache_hit_rates.sql
+++ b/src/cb/query_menu/sql/cache_hit_rates.sql
@@ -1,0 +1,54 @@
+SELECT
+    cache_rates.schemaname,
+    sizes.name AS "Table Name",
+    cache_rates.ratio AS "Cache Hit Ratio",
+    indexes.ratio AS "Index Hit Ratio",
+    CASE WHEN total_reads.cache_reads > 0 THEN ROUND((cache_rates.cache_reads/total_reads.cache_reads * 100), 2) ELSE 0 END AS "Read Percentage",
+    CASE WHEN rowcount.estimate = -1 THEN 0 ELSE rowcount.estimate END AS "Row Count",
+    CASE WHEN size = 8192 THEN '0 bytes' ELSE pg_size_pretty(size) END AS "Size"
+FROM (
+    SELECT
+        n.nspname AS schemaname,
+        c.relname AS name,
+        pg_table_size(c.oid) AS size
+    FROM pg_class c
+    LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+        AND n.nspname !~ '^pg_toast'
+        AND c.relkind='r'
+) AS sizes
+INNER JOIN (
+    SELECT
+        schemaname,
+        relname,
+        (sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read), 0) * 100)::int AS ratio,
+        sum(heap_blks_read) AS cache_reads
+    FROM pg_statio_user_tables
+    GROUP BY relname, schemaname) AS cache_rates ON sizes.name = cache_rates.relname
+        AND sizes.schemaname = cache_rates.schemaname
+    INNER JOIN (
+        SELECT sum(heap_blks_read) AS cache_reads
+        FROM pg_statio_user_tables
+    ) AS total_reads ON 1 = 1
+    LEFT JOIN (
+        SELECT
+            schemaname,
+            relname,
+            (sum(idx_blks_hit) / nullif(sum(idx_blks_hit + idx_blks_read),0) * 100)::int AS ratio
+        FROM pg_statio_user_indexes
+        GROUP BY schemaname,relname
+    ) AS indexes ON sizes.name = indexes.relname
+        AND sizes.schemaname = indexes.schemaname
+    LEFT JOIN (
+        SELECT
+            reltuples AS estimate,
+            c.relname AS name,
+            n.nspname AS schemaname
+        FROM pg_class c
+        LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+        WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+            AND n.nspname !~ '^pg_toast'
+            AND c.relkind='r'
+    ) AS rowcount ON sizes.name = rowcount.name
+         AND sizes.schemaname = rowcount.schemaname
+ORDER BY size DESC

--- a/src/cb/query_menu/sql/connection_management_count_by_state.sql
+++ b/src/cb/query_menu/sql/connection_management_count_by_state.sql
@@ -1,0 +1,8 @@
+SELECT
+    usename AS user_name,
+    state,
+    count(*) AS connection_count
+FROM pg_stat_activity
+WHERE usename NOT IN ('crunchy_replication', 'crunchy_superuser')
+GROUP BY usename, state
+ORDER BY 3 DESC;

--- a/src/cb/query_menu/sql/connection_management_count_by_user_and_application.sql
+++ b/src/cb/query_menu/sql/connection_management_count_by_user_and_application.sql
@@ -1,0 +1,8 @@
+SELECT
+    usename as user_name,
+    application_name,
+    count(*) as connection_count
+FROM pg_stat_activity
+WHERE usename NOT IN ('crunchy_replication', 'crunchy_superuser')
+GROUP BY usename, application_name
+ORDER BY 3 DESC;

--- a/src/cb/query_menu/sql/extensions_available.sql
+++ b/src/cb/query_menu/sql/extensions_available.sql
@@ -1,0 +1,1 @@
+SELECT * FROM pg_available_extensions

--- a/src/cb/query_menu/sql/extensions_installed.sql
+++ b/src/cb/query_menu/sql/extensions_installed.sql
@@ -1,0 +1,1 @@
+SELECT * FROM pg_extension;

--- a/src/cb/query_menu/sql/indexes_duplicates.sql
+++ b/src/cb/query_menu/sql/indexes_duplicates.sql
@@ -1,0 +1,144 @@
+WITH fk_indexes AS (
+    SELECT
+        n.nspname AS schema_name,
+        ci.relname AS index_name,
+        cr.relname AS table_name,
+        (confrelid::regclass)::text AS fk_table_ref,
+        array_to_string(indclass, ', ') AS opclasses
+    FROM pg_index i
+    JOIN pg_class ci ON ci.oid = i.indexrelid AND ci.relkind = 'i'
+    JOIN pg_class cr ON cr.oid = i.indrelid AND cr.relkind = 'r'
+    JOIN pg_namespace n ON n.oid = ci.relnamespace
+    JOIN pg_constraint cn ON cn.conrelid = cr.oid
+    LEFT JOIN pg_stat_user_indexes si ON si.indexrelid = i.indexrelid
+    WHERE contype = 'f'
+        AND i.indisunique IS false
+        AND conkey IS NOT NULL
+        AND ci.relpages > 0 -- raise for a DB with a lot of indexes
+        AND si.idx_scan < 10
+),
+-- Redundant indexes
+index_data AS (
+    SELECT
+        *,
+        (SELECT string_agg(lpad(i, 3, '0'), ' ') FROM unnest(string_to_array(indkey::text, ' ')) i) AS columns,
+        array_to_string(indclass, ', ') AS opclasses
+    FROM pg_index i
+    JOIN pg_class ci ON ci.oid = i.indexrelid AND ci.relkind = 'i'
+    WHERE indisvalid = true AND ci.relpages > 0 -- raise for a DD with a lot of indexes
+),
+redundant_indexes AS (
+    SELECT
+        i2.indexrelid AS index_id,
+        tnsp.nspname AS schema_name,
+        trel.relname AS table_name,
+        pg_relation_size(trel.oid) AS table_size_bytes,
+        irel.relname AS index_name,
+        am1.amname AS access_method,
+        (i1.indexrelid::regclass)::text AS reason,
+        i1.indexrelid AS reason_index_id,
+        pg_get_indexdef(i1.indexrelid) main_index_def,
+        pg_size_pretty(pg_relation_size(i1.indexrelid)) main_index_size,
+        pg_get_indexdef(i2.indexrelid) index_def,
+        pg_relation_size(i2.indexrelid) index_size_bytes,
+        s.idx_scan AS index_usage,
+        quote_ident(tnsp.nspname) AS formated_schema_name,
+        coalesce(nullif(quote_ident(tnsp.nspname), 'public') || '.', '') || quote_ident(irel.relname) AS formated_index_name,
+        quote_ident(trel.relname) AS formated_table_name,
+        coalesce(nullif(quote_ident(tnsp.nspname), 'public') || '.', '') || quote_ident(trel.relname) AS formated_relation_name,
+        i2.opclasses
+    FROM index_data AS i1
+    JOIN index_data AS i2 ON (
+        i1.indrelid = i2.indrelid -- same table
+        AND i1.indexrelid <> i2.indexrelid -- NOT same index
+    )
+    INNER JOIN pg_opclass op1 ON i1.indclass[0] = op1.oid
+    INNER JOIN pg_opclass op2 ON i2.indclass[0] = op2.oid
+    INNER JOIN pg_am am1 ON op1.opcmethod = am1.oid
+    INNER JOIN pg_am am2 ON op2.opcmethod = am2.oid
+    JOIN pg_stat_user_indexes AS s ON s.indexrelid = i2.indexrelid
+    JOIN pg_class AS trel ON trel.oid = i2.indrelid
+    JOIN pg_namespace AS tnsp ON trel.relnamespace = tnsp.oid
+    JOIN pg_class AS irel ON irel.oid = i2.indexrelid
+    WHERE NOT i2.indisprimary -- index 1 IS NOT primary
+        AND NOT (
+            -- skip if index1 IS (primary OR uniq) AND IS NOT (primary AND uniq)
+            i2.indisunique AND NOT i1.indisprimary
+        )
+        AND am1.amname = am2.amname -- same access type
+        AND i1.columns like (i2.columns || '%') -- index 2 includes all columns FROM index 1
+        AND i1.opclasses like (i2.opclasses || '%')
+        -- index expressions IS same
+        AND pg_get_expr(i1.indexprs, i1.indrelid) IS NOT DISTINCT FROM pg_get_expr(i2.indexprs, i2.indrelid)
+        -- index predicates IS same
+        AND pg_get_expr(i1.indpred, i1.indrelid) IS NOT DISTINCT FROM pg_get_expr(i2.indpred, i2.indrelid)
+),
+redundant_indexes_fk AS (
+    SELECT
+        ri.*,
+        (
+        SELECT count(1)
+        FROM fk_indexes fi
+        WHERE
+        fi.fk_table_ref = ri.table_name
+        AND fi.opclasses like (ri.opclasses || '%')
+        ) > 0 AS supports_fk
+        FROM redundant_indexes ri
+    ),
+-- Cut recursive links
+redundant_indexes_tmp_num AS (
+    SELECT
+        row_number() OVER () num,
+        rig.*
+    FROM redundant_indexes_fk rig
+    ORDER BY index_id
+),
+redundant_indexes_tmp_cut AS (
+    SELECT
+        ri1.*,
+        ri2.num AS r_num
+    FROM redundant_indexes_tmp_num ri1
+    LEFT JOIN redundant_indexes_tmp_num ri2 ON ri2.reason_index_id = ri1.index_id
+        AND ri1.reason_index_id = ri2.index_id
+    WHERE ri1.num < ri2.num OR ri2.num IS NULL
+),
+redundant_indexes_cut_grouped AS (
+    SELECT
+    DISTINCT(num),
+    *
+    FROM redundant_indexes_tmp_cut
+    ORDER BY index_size_bytes DESC
+),
+redundant_indexes_grouped AS (
+    SELECT
+    DISTINCT(num),
+    *
+    FROM redundant_indexes_tmp_cut
+    ORDER BY index_size_bytes DESC
+)
+SELECT
+    schema_name,
+    table_name,
+    table_size_bytes,
+    index_name,
+    access_method,
+    string_agg(DISTINCT reason, ', ') AS redundant_to,
+    string_agg(main_index_def, ', ') AS main_index_def,
+    string_agg(main_index_size, ', ') AS main_index_size,
+    index_def,
+    index_size_bytes,
+    index_usage,
+    supports_fk
+FROM redundant_indexes_cut_grouped
+GROUP BY
+    index_id,
+    schema_name,
+    table_name,
+    table_size_bytes,
+    index_name,
+    access_method,
+    index_def,
+    index_size_bytes,
+    index_usage,
+    supports_fk
+ORDER BY index_size_bytes DESC;

--- a/src/cb/query_menu/sql/indexes_list.sql
+++ b/src/cb/query_menu/sql/indexes_list.sql
@@ -1,0 +1,7 @@
+SELECT
+    tablename,
+    indexname,
+    indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+ORDER BY tablename, indexname;

--- a/src/cb/query_menu/sql/indexes_unused.sql
+++ b/src/cb/query_menu/sql/indexes_unused.sql
@@ -1,0 +1,90 @@
+WITH table_scans AS (
+    SELECT
+        relid,
+        tables.idx_scan + tables.seq_scan AS all_scans,
+        ( tables.n_tup_ins + tables.n_tup_upd + tables.n_tup_del ) AS writes,
+        pg_relation_size(relid) AS table_size
+    FROM pg_stat_user_tables AS tables
+),
+all_writes AS (
+    SELECT sum(writes) AS total_writes
+    FROM table_scans
+),
+indexes AS (
+    SELECT
+        idx_stat.relid,
+        idx_stat.indexrelid,
+        idx_stat.schemaname,
+        idx_stat.relname AS tablename,
+        idx_stat.indexrelname AS indexname,
+        idx_stat.idx_scan,
+        pg_relation_size(idx_stat.indexrelid) AS index_bytes,
+        indexdef ~* 'USING btree' AS idx_is_btree
+    FROM pg_stat_user_indexes AS idx_stat
+    JOIN pg_index USING (indexrelid)
+    JOIN pg_indexes AS indexes ON idx_stat.schemaname = indexes.schemaname
+        AND idx_stat.relname = indexes.tablename
+        AND idx_stat.indexrelname = indexes.indexname
+    WHERE pg_index.indisunique = FALSE
+),
+index_ratios AS (
+    SELECT
+        schemaname,
+        tablename,
+        indexname,
+        idx_scan,
+        all_scans,
+        round(( CASE WHEN all_scans = 0 THEN 0.0::NUMERIC
+        ELSE idx_scan::NUMERIC/all_scans * 100 END),2) AS index_scan_pct,
+        writes,
+        round((CASE WHEN writes = 0 THEN idx_scan::NUMERIC ELSE idx_scan::NUMERIC/writes END),2)
+        AS scans_per_write,
+        pg_size_pretty(index_bytes) AS index_size,
+        pg_size_pretty(table_size) AS table_size,
+        idx_is_btree,
+        index_bytes
+    FROM indexes
+    JOIN table_scans USING (relid)
+    WHERE table_size > 8192
+        AND index_bytes > 8192
+),
+index_groups AS (
+    SELECT 'Never Used Indexes' AS reason, *, 1 AS grp
+    FROM index_ratios
+    WHERE idx_scan = 0 AND idx_is_btree
+    UNION ALL
+    SELECT 'Low Scans, High Writes' AS reason, *, 2 AS grp
+    FROM index_ratios
+    WHERE scans_per_write <= 1
+        AND index_scan_pct < 10
+        AND idx_scan > 0
+        AND writes > 100
+        AND idx_is_btree
+    UNION ALL
+    SELECT 'Seldom Used Large Indexes' AS reason, *, 3 AS grp
+    FROM index_ratios
+    WHERE index_scan_pct < 5
+        AND scans_per_write > 1
+        AND idx_scan > 0
+        AND idx_is_btree
+        AND index_bytes > 100000000
+    UNION ALL
+    SELECT 'High-Write Large Non-Btree' AS reason, index_ratios.*, 4 AS grp
+    FROM index_ratios, all_writes
+    WHERE ( writes::NUMERIC / ( total_writes + 1 ) ) > 0.02
+        AND NOT idx_is_btree
+        AND index_bytes > 100000000
+    ORDER BY grp, index_bytes DESC
+)
+SELECT
+    reason,
+    schemaname AS schema_name,
+    tablename AS table_name,
+    indexname AS index_name,
+    index_scan_pct,
+    scans_per_write,
+    index_size,
+    table_size,
+    idx_scan,
+    all_scans
+FROM index_groups;

--- a/src/cb/query_menu/sql/locks_blocking_queries.sql
+++ b/src/cb/query_menu/sql/locks_blocking_queries.sql
@@ -1,0 +1,20 @@
+WITH sos AS (
+	SELECT array_cat(array_agg(pid),
+           array_agg((pg_blocking_pids(pid))[array_length(pg_blocking_pids(pid),1)])) pids
+	FROM pg_locks
+	WHERE NOT granted
+)
+SELECT a.pid, a.usename, a.datname, a.state,
+	   a.wait_event_type || ': ' || a.wait_event AS wait_event,
+       current_timestamp-a.state_change time_in_state,
+       current_timestamp-a.xact_start time_in_xact,
+       l.relation::regclass relname,
+       l.locktype, l.mode, l.page, l.tuple,
+       pg_blocking_pids(l.pid) blocking_pids,
+       (pg_blocking_pids(l.pid))[array_length(pg_blocking_pids(l.pid),1)] last_session,
+       COALESCE((pg_blocking_pids(l.pid))[1]||'.'||COALESCE(CASE WHEN locktype='transactionid' THEN 1 ELSE array_length(pg_blocking_pids(l.pid),1)+1 END,0),a.pid||'.0') lock_depth,
+       a.query
+FROM pg_stat_activity a
+     JOIN sos s ON (a.pid = any(s.pids))
+     LEFT OUTER JOIN pg_locks l on (a.pid = l.pid and not l.granted)
+ORDER BY lock_depth;

--- a/src/cb/query_menu/sql/query_performance_most_consuming_system_time.sql
+++ b/src/cb/query_menu/sql/query_performance_most_consuming_system_time.sql
@@ -1,0 +1,11 @@
+SELECT
+    (total_exec_time + total_plan_time)::int AS total_time,
+    total_exec_time::int AS total_execution_time,
+    total_plan_time::int AS total_planning_time,
+    mean_exec_time::int AS average_execution_time,
+    calls,
+    query
+FROM pg_stat_statements
+WHERE query != '<insufficient privilege>'
+ORDER BY total_time DESC
+LIMIT 50;

--- a/src/cb/query_menu/sql/query_performance_over_one_minute.sql
+++ b/src/cb/query_menu/sql/query_performance_over_one_minute.sql
@@ -1,0 +1,11 @@
+SELECT
+    pid,
+    now() - pg_stat_activity.query_start AS duration,
+    query_id::text,
+    query
+FROM pg_stat_activity
+WHERE pg_stat_activity.query <> ''::text
+    AND state <> 'idle'
+    AND now() - pg_stat_activity.query_start > interval '1 minute'
+    AND usesysid not in (SELECT usesysid FROM pg_user WHERE usename like 'crunchy_%')
+ORDER BY now() - pg_stat_activity.query_start DESC;

--- a/src/cb/query_menu/sql/query_performance_slowest_average.sql
+++ b/src/cb/query_menu/sql/query_performance_slowest_average.sql
@@ -1,0 +1,11 @@
+SELECT
+    (mean_exec_time + mean_plan_time)::int AS average_time,
+    mean_exec_time::int AS average_execution_time,
+    mean_plan_time::int AS average_planning_time,
+    calls,
+    query
+FROM pg_stat_statements
+WHERE calls > 1
+    AND query != '<insufficient privilege>'
+ORDER BY average_time DESC
+LIMIT 50;

--- a/src/cb/query_menu/sql/size_information_database_size.sql
+++ b/src/cb/query_menu/sql/size_information_database_size.sql
@@ -1,0 +1,60 @@
+WITH data AS (
+    SELECT
+        d.oid,
+        (SELECT spcname FROM pg_tablespace WHERE oid = dattablespace) AS tblspace,
+        d.datname AS database_name,
+        pg_catalog.pg_get_userbyid(d.datdba) AS owner,
+        has_database_privilege(d.datname, 'connect') AS has_access,
+        pg_database_size(d.datname) AS size,
+        blks_hit,
+        blks_read,
+        temp_files,
+        temp_bytes
+    FROM pg_catalog.pg_database d
+    JOIN pg_stat_database s on s.datid = d.oid
+    WHERE d.datname not in ('template1', 'crunchy_monitoring', 'template0')
+), data2 AS (
+    SELECT
+        NULL::oid AS oid,
+        NULL AS tblspace,
+        '*** TOTAL ***' AS database_name,
+        NULL AS owner,
+        true AS has_access,
+        sum(size) AS size,
+        sum(blks_hit) AS blks_hit,
+        sum(blks_read) AS blks_read,
+        sum(temp_files) AS temp_files,
+        sum(temp_bytes) AS temp_bytes
+    FROM data
+    UNION all
+    SELECT NULL::oid, NULL, NULL, NULL, true, NULL, NULL, NULL, NULL, NULL
+    UNION all
+    SELECT
+        oid,
+        tblspace,
+        database_name,
+        owner,
+        has_access,
+        size,
+        blks_hit,
+        blks_read,
+        temp_files,
+        temp_bytes
+    FROM data
+)
+SELECT
+    database_name || coalesce(' [' || nullif(tblspace, 'pg_default') || ']', '') AS "Database",
+    CASE WHEN has_access THEN
+        pg_size_pretty(size) || ' (' || round(
+            100 * size::numeric / nullif(sum(size) over (partition by (oid is NULL)), 0),
+            2
+        )::text || '%)'
+    ELSE 'no access'
+    END AS "Size",
+    CASE WHEN blks_hit + blks_read > 0 THEN
+        (round(blks_hit * 100::numeric / (blks_hit + blks_read), 2))::text || '%'
+    ELSE NULL
+    END AS "Cache eff.",
+    temp_files::text || coalesce(' (' || pg_size_pretty(temp_bytes) || ')', '') AS "Temp. Files"
+FROM data2
+ORDER BY oid is NULL DESC, size DESC NULLS LAST;

--- a/src/cb/query_menu/sql/size_information_table_size.sql
+++ b/src/cb/query_menu/sql/size_information_table_size.sql
@@ -1,0 +1,51 @@
+WITH RECURSIVE pg_inherit(inhrelid, inhparent) AS (
+    SELECT inhrelid, inhparent
+    FROM pg_inherits
+    UNION
+    SELECT child.inhrelid, parent.inhparent
+    FROM pg_inherit child, pg_inherits parent
+    WHERE child.inhparent = parent.inhrelid
+),
+pg_inherit_short AS (
+    SELECT *
+    FROM pg_inherit
+    WHERE inhparent NOT IN (SELECT inhrelid FROM pg_inherit)
+)
+SELECT
+    table_schema
+    , TABLE_NAME
+    , CASE WHEN row_estimate = -1 THEN 0 ELSE row_estimate END
+    , CASE WHEN total_bytes = 8192 THEN '0 bytes' ELSE pg_size_pretty(total_bytes) END as "Total"
+    , CASE WHEN index_bytes = 8192 THEN '0 bytes' ELSE pg_size_pretty(index_bytes) END as "Index"
+    , CASE WHEN toast_bytes = 8192 THEN '0 bytes' ELSE pg_size_pretty(toast_bytes) END as "Toast"
+    , CASE WHEN table_bytes = 8192 THEN '0 bytes' ELSE pg_size_pretty(table_bytes) END as "Table"
+FROM (
+    SELECT *
+    , total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes
+    FROM (
+        SELECT c.oid
+            , nspname AS table_schema
+            , relname AS TABLE_NAME
+            , SUM(c.reltuples) OVER (partition BY parent) AS row_estimate
+            , SUM(pg_total_relation_size(c.oid)) OVER (partition BY parent) AS total_bytes
+            , SUM(pg_indexes_size(c.oid)) OVER (partition BY parent) AS index_bytes
+            , SUM(pg_total_relation_size(reltoastrelid)) OVER (partition BY parent) AS toast_bytes
+            , parent
+        FROM (
+            SELECT
+                pg_class.oid
+                , reltuples
+                , relname
+                , relnamespace
+                , pg_class.reltoastrelid
+                , COALESCE(inhparent, pg_class.oid) parent
+            FROM pg_class
+            LEFT JOIN pg_inherit_short ON inhrelid = oid
+            WHERE relkind IN ('r', 'p')
+        ) c
+        LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE NOT nspname in ('pg_catalog', 'information_schema')
+    ) a
+    WHERE oid = parent
+) a
+ORDER BY total_bytes DESC;

--- a/src/tools/embed_base64.cr
+++ b/src/tools/embed_base64.cr
@@ -1,0 +1,10 @@
+require "base64"
+
+filename = ARGV[0]
+
+begin
+  puts Base64.encode File.read(filename)
+rescue e : File::Error
+  STDERR.puts e.message
+  exit 1
+end


### PR DESCRIPTION
This is an initial phase of supporting a builtin menu of useful queries when using `cb psql`. Currently, it only supports predefined queries. To access this menu, simply enter `:menu` into psql and it will present the available query options.

Example:

```
Example Team/example-cluster/postgres=> :menu
Cache
  1 – Cache and index hit rates
Size Information
  2 – Database sizes
  3 – Table sizes
Query Performance
  4 – Queries consuming the most system time
  5 – Queries running over 1 minute
  6 – Slowest average queries
Connection Management
  7 – Connection count by state
  8 – Connection count by user and application
Indexes
  9 – Duplicate indexes
  10 – List of indexes
  11 – Unused indexes
Locks
  12 – Blocking queries
Extensions
  13 – Available extensions
  14 – Installed extensions

Type choice and press <Enter> (q to quit):

```