### PR TITLE
Fix `crystal v1.11` warnings for use of `splat` in macros.

### DIFF
--- a/src/ext/stdlib_ext.cr
+++ b/src/ext/stdlib_ext.cr
@@ -35,7 +35,7 @@ end
 
 macro jrecord(name, *properties)
   @[JSON::Serializable::Options(emit_nulls: true)]
-  record({{name}}, {{*properties}}) do
+  record({{name}}, {{properties.splat}}) do
     include JSON::Serializable
 
     {{yield}}


### PR DESCRIPTION
In `crystal v1.11.0` the use of the `splat (*)` operator in macro expressions was deprecated[1,2,3]. Instead it is recommended to use `.splat` instead. Currently, we are not building against `crystal v1.11`, however, we do want to move to it in near future. So here we're making these changes to get ahead of it.

```
Warning: Deprecated use of splat operator. Use `#splat` instead
```

[1] https://crystal-lang.org/2024/01/08/1.11.0-released/
[2] https://github.com/crystal-lang/crystal/releases/tag/1.11.0
[3] https://github.com/crystal-lang/crystal/pull/13939