### PR TITLE
Update to a newer version of our crystal flake

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -3,6 +3,10 @@
 # The point is for the user to remove these configuration records
 # one by one as the reported problems are removed from the code base.
 
+# Seems broken in current (v1.6.1) build of ameba, so disabling
+Lint/UselessAssign:
+  Enabled: false
+
 # Problems found: 6
 # Run `ameba --only Naming/AccessorMethodName` for details
 Naming/AccessorMethodName:

--- a/flake.lock
+++ b/flake.lock
@@ -1,48 +1,15 @@
 {
   "nodes": {
-    "ameba-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1700856784,
-        "narHash": "sha256-jgdIxm6+kIuqbOpwOUSle3o5WIb9PPYsztojnJNbt54=",
-        "owner": "crystal-ameba",
-        "repo": "ameba",
-        "rev": "47088b10ca97aff96c9580ff50b17cd4e945a175",
-        "type": "github"
-      },
-      "original": {
-        "owner": "crystal-ameba",
-        "repo": "ameba",
-        "type": "github"
-      }
-    },
-    "crystal-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1697181881,
-        "narHash": "sha256-+ytVFf0t6ZDcJ+bQaDC012/YlOTpo7G6WGBMGlRltt4=",
-        "owner": "crystal-lang",
-        "repo": "crystal",
-        "rev": "c6f3552f5be159eb06c8f348c6b9e23ff7f17dbc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "crystal-lang",
-        "ref": "release/1.10",
-        "repo": "crystal",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -56,11 +23,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -69,13 +36,29 @@
         "type": "github"
       }
     },
+    "lastGoodStaticBoehmgc": {
+      "locked": {
+        "lastModified": 1710266477,
+        "narHash": "sha256-oChjOWfSxtY5508wFhQQ/MS092+Xxzfj9vnv53VNHCE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14feac318eefa31d936d9b6a2aacb1928899abfe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14feac318eefa31d936d9b6a2aacb1928899abfe",
+        "type": "github"
+      }
+    },
     "nix-filter": {
       "locked": {
-        "lastModified": 1694857738,
-        "narHash": "sha256-bxxNyLHjhu0N8T3REINXQ2ZkJco0ABFPn6PIe2QUfqo=",
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "41fd48e00c22b4ced525af521ead8792402de0ea",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
         "type": "github"
       },
       "original": {
@@ -86,11 +69,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701040486,
-        "narHash": "sha256-vawYwoHA5CwvjfqaT3A5CT9V36Eq43gxdwpux32Qkjw=",
+        "lastModified": 1711593151,
+        "narHash": "sha256-/9NCoPI7fqJIN8viONsY9X0fAeq8jc3GslFCO0ky6TQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "45827faa2132b8eade424f6bdd48d8828754341a",
+        "rev": "bb2b73df7bcfbd2dd55ff39b944d70547d53c267",
         "type": "github"
       },
       "original": {
@@ -102,37 +85,22 @@
     },
     "nixpkgs-crunchy": {
       "inputs": {
-        "ameba-src": "ameba-src",
-        "crystal-src": "crystal-src",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "lastGoodStaticBoehmgc": "lastGoodStaticBoehmgc",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1701184205,
-        "narHash": "sha256-fxkfz2id02FNv+X0wugv1YNUjCGjpvkQaRtKAjvvGQY=",
+        "lastModified": 1711620066,
+        "narHash": "sha256-RJZTdHUdznGxnWP+dvcrClGg8ctYggAlIrc4drujtUA=",
         "owner": "crunchydata",
         "repo": "nixpkgs",
-        "rev": "cafe78b190a5e7610489535a7afa96bce25217a6",
+        "rev": "cafe229c653d9961f7d0b2123fccb8488d8c9c42",
         "type": "github"
       },
       "original": {
         "owner": "crunchydata",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1697379843,
-        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs-crunchy.url = "github:crunchydata/nixpkgs";
+    nixpkgs-crunchy = { url = "github:crunchydata/nixpkgs"; inputs.nixpkgs.follows = "nixpkgs"; };
     nix-filter.url = "github:numtide/nix-filter";
   };
 


### PR DESCRIPTION
The main nixpkgs repo is doing a better job of staying up-to-date with crystal releases, so I've removed most of what we were doing to build our own crystal compiler, and drop down to just some quality-of-life wrapping with common libraries.

Also now updating cb to use newer versions can happen by only updating the nixpkgs reference here, since the crunchydata/nixpkgs flake can be told to follow that input.