### PR TITLE
Update github release runner to include macos arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
-      - uses: cachix/cachix-action@v12
+        uses: cachix/install-nix-action@v26
+      - uses: cachix/cachix-action@v14
         with:
           name: crunchy-public
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: nix flake check
         run:  nix flake check --print-build-logs --keep-going

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Nix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         make release RELEASE=1 STATIC=1
 
     - name: Upload release bundle artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cb_linux_amd64
         path: dist
@@ -47,13 +47,13 @@ jobs:
       run: shards install
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
       with:
         version: latest
 
@@ -62,12 +62,39 @@ jobs:
         make release RELEASE=1 STATIC=1 TARGET_ARCH=aarch64
 
     - name: Upload release bundle artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cb_linux_aarch64
         path: dist
 
   build_macos_amd64:
+    runs-on: macos-13
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install crystal
+      run: brew install crystal
+
+    - name: Install gon via homebrew for code signing and app notarization
+      run: |
+        brew tap mitchellh/gon
+        brew install mitchellh/gon/gon
+
+    - name: Install dependencies
+      run: shards install
+
+    - name: Build
+      run: |
+        make release RELEASE=1 STATIC_LIBS=1
+
+    - name: Upload release bundle artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: cb_macos_amd64
+        path: dist
+
+  build_macos_arm64:
     runs-on: macos-latest
     steps:
     - name: Checkout
@@ -89,36 +116,36 @@ jobs:
         make release RELEASE=1 STATIC_LIBS=1
 
     - name: Upload release bundle artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: cb_macos_amd64
+        name: cb_macos_arm64
         path: dist
 
   release:
-    needs: [build_linux_amd64, build_linux_aarch64, build_macos_amd64]
+    needs: [build_linux_amd64, build_linux_aarch64, build_macos_amd64, build_macos_arm64]
     runs-on: ubuntu-latest
     steps:
     - name: Determine version
       id: version
-      run: "echo ::set-output name=version::${GITHUB_REF:11}"
+      run: echo "version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
 
     - name: Download cb_linux_amd64.zip artifact
       id: download_linux_amd64
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: cb_linux_amd64
         path: dist-linux-amd64
 
     - name: Download cb_linux_aarch64.zip artifact
       id: download_linux_aarch64
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: cb_linux_aarch64
         path: dist-linux-aarch64
 
     - name: Download cb_macos_amd64.zip artifact
       id: download_macos_amd64
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: cb_macos_amd64
         path: dist-macos-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Add Crystal repos
       run: curl -sSL https://crystal-lang.org/install.sh | sudo bash
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Add Crystal repos
       run: curl -sSL https://crystal-lang.org/install.sh | sudo bash
@@ -71,7 +71,7 @@ jobs:
     runs-on: macos-13
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install crystal
       run: brew install crystal
@@ -98,7 +98,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install crystal
       run: brew install crystal


### PR DESCRIPTION
Previously, the github `macos-latest` runner was still an amd64/x86_64 architecture. As such we were not able to have a purely Apple Silicon build through the github release workflow. However, the `macos-latest` runner is now supported by Apple Silicon[1]. As such we need to create a specific build target for it in `.github/workflows/release.yml` as well as update the `build_macos_amd64` target to use the `macos-13` runner such that that architecture is still being built.

This will add an extra artifact to the releases which should allow for an easier and perhaps more seamless homebrew release process.

[1] https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories