### PR TITLE
Fix `cb uri` hostname for replicas using `user` role.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - `cb config-param set` issue truncating values with multiple `=` characters.
+- `cb uri` retrieving correct `user` role credentials for a replica.
 
 ## [3.5.0] - 2024-01-31
 ### Added

--- a/spec/cb/cluster_uri_spec.cr
+++ b/spec/cb/cluster_uri_spec.cr
@@ -31,6 +31,7 @@ Spectator.describe CB::ClusterURI do
       action.role = "user"
 
       expect(client).to receive(:create_role).and_return(role)
+      expect(client).to receive(:get_role).and_return(role)
 
       action.call
 
@@ -48,6 +49,7 @@ Spectator.describe CB::ClusterURI do
       action.role = "user"
 
       expect(client).to receive(:create_role).and_return(role)
+      expect(client).to receive(:get_role).and_return(role)
 
       action.call
 

--- a/src/cb/cluster_uri.cr
+++ b/src/cb/cluster_uri.cr
@@ -15,11 +15,8 @@ class CB::ClusterURI < CB::APIAction
   def run
     validate
 
-    role = if @role == "user"
-             client.create_role(@cluster_id[:cluster])
-           else
-             client.get_role(@cluster_id[:cluster], @role.to_s)
-           end
+    client.create_role(@cluster_id[:cluster]) if @role == "user"
+    role = client.get_role(@cluster_id[:cluster], @role.to_s)
 
     uri = role.uri
     raise Error.new "There is no URI available for this cluster." unless uri


### PR DESCRIPTION
It was reported that using `cb uri` to retrieve credentials for a `user` role on a replica was returning the hostname of the `primary` instead of the target replica.

This was because it's possible that the` user` role does not exist yet and therefore would need to first be created on the primary. So, to ensure that it is, we always attempt to create it on the primary and then retrieve it for the replica. Previously, we were only creating it and that was resulting in the returned credentials to be associated with the primary. So, we've now eliminated that branch in the code so that it will always retrieve this information from the correct target.