### PR TITLE
Fix config param valus being truncated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `cb config-param set` issue truncating values with multiple `=` characters.
 
 ## [3.5.0] - 2024-01-31
 ### Added

--- a/spec/cb/config_param_spec.cr
+++ b/spec/cb/config_param_spec.cr
@@ -147,7 +147,10 @@ Spectator.describe ConfigurationParameterSet do
 
   describe "#call" do
     before_each {
-      action.args = ["postgres:max_connections=100"]
+      action.args = [
+        "postgres:max_connections=100",
+      ]
+
       action.cluster_id = cluster.id
     }
 

--- a/spec/support/factory.cr
+++ b/spec/support/factory.cr
@@ -101,6 +101,18 @@ module Factory
     CB::Model::ClusterStatus.new **params
   end
 
+  def configuration_parameter(**params)
+    params = {
+      component:        "postgres",
+      name:             "postgres:max_connections",
+      parameter_name:   "max_connections",
+      requires_restart: false,
+      value:            "100",
+    }.merge(params)
+
+    CB::Model::ConfigurationParameter.new **params
+  end
+
   def firewall_rule(**params)
     params = {
       id:   "shofthj3fzaipie44lt6a5i3de",
@@ -181,18 +193,6 @@ module Factory
     }.merge(params)
 
     CB::Model::Role.new **params
-  end
-
-  def configuration_parameter(**params)
-    params = {
-      component:        "postgres",
-      name:             "postgres:max_connections",
-      parameter_name:   "max_connections",
-      requires_restart: false,
-      value:            "100",
-    }.merge(params)
-
-    CB::Model::ConfigurationParameter.new **params
   end
 
   def role_user(**params)

--- a/src/cb/config_param.cr
+++ b/src/cb/config_param.cr
@@ -126,7 +126,7 @@ module CB
       super
 
       updated_parameters = @args.map do |arg|
-        parts = arg.split('=')
+        parts = arg.split(separator: '=', limit: 2)
         {"name" => parts[0], "value" => parts[1]}
       rescue IndexError
         raise Error.new("Invalid argument: #{arg}). Make sure that it has the following format <component>:<name>=<value>.")


### PR DESCRIPTION
It was reported that the `cb config-param set` command was truncating values that contain a `=` character. This was due to how the input line was being parsed and tokenized. Here, we've simply limited the parsing to the first instance of this character such that it will only ever split the parameter name and value from the input.