### PR TITLE
Fix `cb psql` line wrapping issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - `cb config-param set` issue truncating values with multiple `=` characters.
+- `cb psql` prompt line wrapping issue.
 - `cb uri` retrieving correct `user` role credentials for a replica.
 
 ## [3.5.0] - 2024-01-31

--- a/spec/cb/psql_spec.cr
+++ b/spec/cb/psql_spec.cr
@@ -52,6 +52,7 @@ Spectator.describe CB::Psql do
 
       expect(client).to receive(:get_cluster).and_return(cluster)
       expect(client).to receive(:create_role).and_return(role)
+      expect(client).to receive(:get_role).and_return(role)
       expect(client).to receive(:get_team).and_return(team)
 
       action.call


### PR DESCRIPTION
It was reported in #158 that `cb psql` was having an issue with line wrapping when text was entered beyond the bounds of the terminal window. It turns out that this issue was related to characters in the prompt being `Colorized`. And it was these bytes of the resulting string that were causing the issue. So, we've simply removed the `Colorize` step associated with this particular output. This does not impact the coloring of the text in the prompt as that's part of the configured `PROMPT1` in the resulting `.psqlrc`.

We've also take the opportunity here to update the uri fetching for the `user` role which was missed as part of #162.