### PR TITLE
Fix expired session login redirect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `cb info` now displays `tailscale` status.
 - `cb network` now manages firewall rules and supports the following
   subcommands: `add-firewall-rule`, `list-firewall-rules`,
   `remove-firewall-rule` and `update-firewall-rule`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cb firewall` deprecated in favor of `cb network`.
 
 ### Fixed
+- Expired session handling not prompting for new login.
 - `cb list` completion to include `--format`.
 
 ## [3.5.1] - 2024-05-09

--- a/spec/cb/cluster_info_spec.cr
+++ b/spec/cb/cluster_info_spec.cr
@@ -42,6 +42,7 @@ Spectator.describe CB::ClusterInfo do
                   platform: aws
                     region: us-east-2
         maintenance window: no window set. Default to: 00:00-23:59
+          tailscale active: false
                    network: nfpvoqooxzdrriu6w3bhqo55c4
                   firewall: no rules\n
       EXPECTED

--- a/spec/support/factory.cr
+++ b/spec/support/factory.cr
@@ -87,6 +87,7 @@ module Factory
       maintenance_window_start: nil,
       network_id:               "nfpvoqooxzdrriu6w3bhqo55c4",
       storage:                  1234,
+      tailscale_active:         false,
     }.merge(params)
 
     CB::Model::Cluster.new **params

--- a/src/cb/cluster_info.cr
+++ b/src/cb/cluster_info.cr
@@ -28,6 +28,7 @@ class CB::ClusterInfo < CB::APIAction
       "platform"           => c.provider_id,
       "region"             => c.region_id,
       "maintenance window" => MaintenanceWindow.new(c.maintenance_window_start).explain,
+      "tailscale active"   => c.tailscale_active,
     }
 
     if source = c.source_cluster_id

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -1006,14 +1006,9 @@ rescue e : CB::Program::Error
 
   exit 1
 rescue e : CB::Client::Error
-  if e.unauthorized?
-    # if PROG.ensure_token_still_good
-    #   STDERR << "error".colorize.t_warn << ": Token had expired, but has been refreshed. Please try again.\n"
-    #   exit 1
-    # end
-  end
-  STDERR.puts e
-  exit 2
+  STDERR << "error".colorize.red.bold << ": #{e.message}\n"
+  exit 2 unless e.unauthorized?
+  CB::Login.new.run
 rescue e
   capture_error e
   exit 3


### PR DESCRIPTION
When we switched to session based authentication from token based, we
introduced an undesired UX issue when a session expires. In summary,
when a session expires, the desired functionality is that the user will
be presented with a message indicating the expiration and prompted to
login in again.

While the first of these was occuring in the form of a formatted HTTP
error output the latter was not. Also, the form of the error was less
than desirable too.

Therefore, what we've done here is updated the error handling around
session expiration/unauthorized errors to prompt the user to login
again.  Also, we've taken the opporunity to clean up the error output of
other API errors as well such that it's presents the error. Use of
`HTTP_DEBUG` is still supported if the full HTTP error details is
necessary for debugging purposes.

