### PR TITLE
Actually use user's ~/.psqlrc file

### DIFF
--- a/src/cb.cr
+++ b/src/cb.cr
@@ -14,6 +14,8 @@ module CB
 
   DASHBOARD_HOST = ENV["CB_DASHBOARD_HOST"]? || HOST.gsub(/\Aapi\./, "")
 
+  PSQLRC = File.expand_path(ENV["PSQLRC"]? || "~/.psqlrc", home: true)
+
   # Release constants.
   BUILD_RELEASE  = {{ flag?(:release) }}
   SHARDS_VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}

--- a/src/cb/psql.cr
+++ b/src/cb/psql.cr
@@ -95,7 +95,7 @@ module CB
       end
 
       psqlrc = File.tempfile(c.id, "psqlrc")
-      File.copy("~/.psqlrc", psqlrc.path) if File.exists?("~/.psqlrc")
+      File.copy(CB::PSQLRC, psqlrc.path) if File.exists?(CB::PSQLRC)
       File.open(psqlrc.path, "a") do |f|
         f.puts "\\set ON_ERROR_ROLLBACK interactive"
         f.puts "\\set PROMPT1 '#{psqlpromptname}/%[%033[33;1m%]%x%x%x%[%033[0m%]%[%033[1m%]%/%[%033[0m%]%R%# '"


### PR DESCRIPTION
Hey! Happy Bridge customer here. 👋😄

Since as long as I remember, my `~/.psqlrc` customizations have never been available in `cb psql` sessions. Despite [this commit](https://github.com/CrunchyData/bridge-cli/commit/0a2211b78b203a72d3608a06aee519ddd6570c05), for instance, I think this probably never worked? Related changes in Crystal behavior seem to go [a while back](https://github.com/crystal-lang/crystal/commit/b98c0ffa82e78b4c3b586fdcb985c145417d3547).

Here’s the fix, confirmed to work on my machine. (It’s awesome being able to test by just swapping `cb` for `src/cli.cr`!)

Given specs were green and still are, I assume that part just isn’t tested so didn’t study the test suite to find where to add it.