### PR TITLE
Add `pagination` support for specific commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Pagination limit on `cb list`, `cb network list`, `cb team list` and
+  `cb team_member list`.
 
 ## [3.6.1] - 2024-11-05
 ### Added

--- a/src/client/client.cr
+++ b/src/client/client.cr
@@ -3,6 +3,7 @@ require "json"
 require "log"
 require "promise"
 require "../ext/stdlib_ext"
+require "./pagination"
 
 module CB
   class Client

--- a/src/client/pagination.cr
+++ b/src/client/pagination.cr
@@ -1,0 +1,4 @@
+macro pagination_properties
+  property has_more : Bool = false
+  property next_cursor : String? = nil
+end

--- a/src/ui/spinner.cr
+++ b/src/ui/spinner.cr
@@ -4,7 +4,7 @@ module CB
 
     def initialize(@text : String = "", @io : IO = IO::Memory.new)
       @chars = ["|", "/", "-", "\\"].map { |c| "#{c.colorize.blue}" }
-      @delay = 0.2
+      @delay = 200.milliseconds
       @running = false
 
       # Control Sequence to allow overwriting the line so that the spinner can


### PR DESCRIPTION
Add pagination support for specific commands to allow for list ALL the
resources they are associated with. They do NOT allow for the end user
to specify a limit/page size at this time. This is meant as an interim
fix to allow for users with large numbers of clusters, team, team
members and networks to be able list them all at one time.


