### PR TITLE
`cb logs`: Use tempkey `.host`

### DIFF
--- a/src/cb/logs.cr
+++ b/src/cb/logs.cr
@@ -18,8 +18,7 @@ module CB
 
       tk = Tempkey.for_cluster cluster_id[:cluster], client: client
 
-      host = "p.#{cluster_id[:cluster]}.db.postgresbridge.com"
-      socket = TCPSocket.new(host, 22, connect_timeout: 1)
+      socket = TCPSocket.new(tk.host, 22, connect_timeout: 1)
       ssh = SSH2::Session.new(socket)
       ssh.login_with_data("cormorant", tk.private_key, tk.public_key)
 

--- a/src/cb/tempkey.cr
+++ b/src/cb/tempkey.cr
@@ -1,5 +1,5 @@
 module CB
-  record Tempkey, private_key : String, public_key : String, cluster_id : String, team_id : String, expires_at : Time do
+  record Tempkey, host : String, private_key : String, public_key : String, cluster_id : String, team_id : String, expires_at : Time do
     Cacheable.include key: cluster_id
 
     def self.for_cluster(cluster_id : Identifier, client) : Tempkey


### PR DESCRIPTION
This uses the `.host` from the tempkey JSON instead of the hardcoded format, which is useful when using an alternative `CB_HOST`.