### PR TITLE
Update cluster `state` enum with new values.

### DIFF
--- a/src/models/cluster_status.cr
+++ b/src/models/cluster_status.cr
@@ -7,12 +7,16 @@ module CB::Model
     enum State
       Creating
       Destroying
-      Unknown
+      Finalizing
       Ready
+      Replaying
       Restarting
+      Restoring
       Resuming
+      Starting
       Suspended
       Suspending
+      Unknown
 
       def to_s(io : IO)
         io << self.to_s.downcase


### PR DESCRIPTION
Updates the cluster `state` enum with recently exposed state values.
This is currently an exhaustive list of possible cluster states.
