### PR TITLE
Add missing upgrade operation enum values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Missing values from cluster upgrade operation state enum
 
 ## [3.6.4] - 2025-04-07
 ### Added

--- a/src/models/operation.cr
+++ b/src/models/operation.cr
@@ -19,13 +19,20 @@ module CB::Model
     enum State
       Canceling
       Creating
+      Destroying
       DisablingHA
       EnablingHA
       FailingOver
+      Finalizing
       InProgress
       Ready
-      ReplayingWAL
-      Scheduled
+      Replaying
+      Restarting
+      Restoring
+      Resuming
+      Starting
+      Suspended
+      Suspending
       WaitingForHAStandby
 
       def to_s(io : IO) : Nil


### PR DESCRIPTION
It was reported that some upgrade operation states being returned by the
API were causing an error due to them being unknown. So, here we're
syncing the related enum to sync with all of the currently supported
and valid values.
