### PR TITLE
update crystal 1.16 -> 1.18

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761656231,
-        "narHash": "sha256-EiED5k6gXTWoAIS8yQqi5mAX6ojnzpHwAQTS3ykeYMg=",
+        "lastModified": 1761880412,
+        "narHash": "sha256-QoJjGd4NstnyOG4mm4KXF+weBzA2AH/7gn1Pmpfcb0A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e99366c665bdd53b7b500ccdc5226675cfc51f45",
+        "rev": "a7fc11be66bdfb5cdde611ee5ce381c183da8386",
         "type": "github"
       },
       "original": {

--- a/src/cb/query_menu/query_menu.cr
+++ b/src/cb/query_menu/query_menu.cr
@@ -9,7 +9,7 @@ module CB::QueryMenu
     private property path : String = ""
 
     def render(cluster : CB::Model::Cluster) : String
-      temp_dir = "/tmp/crunchy/cli/#{cluster.name}-#{cluster.id}-queries"
+      temp_dir = "#{Dir.tempdir}/crunchy/cli/#{cluster.name}-#{cluster.id}-queries"
       FileUtils.mkdir_p(temp_dir) unless File.exists? temp_dir
 
       # Aggregate all queries and group them by category in alphabetical order.


### PR DESCRIPTION
```
<<< /nix/store/6sk9jhxaqa01jm0wp0b4x9labcyi5a3c-cb-3.6.7.drv
>>> /nix/store/jwxavs1iq4zp0bshivkz508js1s8f6g2-cb-3.6.7.drv
Version changes:
[C.]  #01  binutils-with-gold               2.44.tar.bz2 x2 -> 2.44.tar.bz2
[C.]  #02  builder.pl                       <none> x3 -> <none> x2
[C.]  #03  cctools-binutils-darwin-wrapper  1010.6 x7 -> 1010.6 x5
[C.]  #04  clang                            20.1.8, 21.1.2 x2 -> 21.1.2 x2
[C.]  #05  clang-at-least                   16-LLVMgold-path.patch x4 -> 16-LLVMgold-path.patch x3
[C.]  #06  clang-src                        20.1.8, 21.1.2 x2 -> 21.1.2 x2
[C.]  #07  clang-wrapper                    20.1.8 x3, 21.1.2 x3 -> 21.1.2 x3
[C.]  #08  compiler-rt                      20.1.8, 21.1.2 -> 21.1.2
[C.]  #09  compiler-rt-libc                 20.1.8, 21.1.2 -> 21.1.2
[C.]  #10  compiler-rt-src                  20.1.8, 21.1.2 -> 21.1.2
[C.]  #11  cpio                             2.15 x3, 2.15.tar.bz2 x2 -> 2.15 x2, 2.15.tar.bz2
[C*]  #12  crystal                          1.10.1-1-darwin-universal.tar.gz, 1.16.3 -> 1.10.1-1-darwin-universal.tar.gz, 1.18.2
[C.]  #13  expand-response-params           <none> x5 -> <none> x4
[C.]  #14  gnu-install-dirs.patch           <none> x4 -> <none> x3
[C.]  #15  jq                               1.8.1 x2, 1.8.1.tar.gz x2 -> 1.8.1, 1.8.1.tar.gz
[C.]  #16  libbfd-plugin-api-header         <none> x3 -> <none> x2
[C.]  #17  libcxx                           19.1.2+apple-sdk-15.5 x5 -> 19.1.2+apple-sdk-15.5 x4
[C.]  #18  llvm                             18-compatibility.patch, 20.1.8, 21.1.2 x2 -> 18-compatibility.patch, 21.1.2 x2
[C.]  #19  llvm-src                         20.1.8, 21.1.2 x2 -> 21.1.2 x2
[C.]  #20  llvm-tblgen                      20.1.8, 21.1.2 x2 -> 21.1.2 x2
[C.]  #21  llvm-tblgen-src                  20.1.8, 21.1.2 x2 -> 21.1.2 x2
[C.]  #22  macOS-SDK                        11.3 x2, 14.4, 15.5 x3 -> 11.3 x2, 14.4, 15.5 x2
[C.]  #23  make-binary-wrapper-hook         <none> x4 -> <none> x3
[C.]  #24  onig                             6.9.10.tar.gz x2 -> 6.9.10.tar.gz
[C.]  #25  oniguruma                        6.9.10 x2 -> 6.9.10
[C.]  #26  pbzx                             1.0.2 x3 -> 1.0.2 x2
[C.]  #27  psutil                           7.1.0.tar.gz x2 -> 7.1.0.tar.gz
[C.]  #28  python3                          3.13.8 x2, 3.13.8-env x2 -> 3.13.8 x2, 3.13.8-env
[C.]  #29  python3.13-psutil                7.1.0 x2 -> 7.1.0
[C*]  #30  source                           <none> x85 -> <none> x83
[C*]  #31  stdenv-darwin                    <none> x5 -> <none> x3
Removed packages:
[R.]  #1  bd49bbaaafc98433a2cb4e95ce25b7a201baf5a5.patch  <none>
Closure size: 1239 -> 1201 (806 paths added, 844 paths removed, delta -38, disk usage -161.7KiB).
```