### PR TITLE
Update GH Actions to resolve Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: nix flake check
         run:  nix flake check --print-build-logs --keep-going

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install crystal
       uses: crystal-lang/install-crystal@v1
@@ -28,7 +28,7 @@ jobs:
         make release RELEASE=1 STATIC=1
 
     - name: Upload release bundle artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: cb_linux_amd64
         path: dist
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install crystal
       uses: crystal-lang/install-crystal@v1
@@ -48,13 +48,13 @@ jobs:
       run: shards install
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         version: latest
 
@@ -63,7 +63,7 @@ jobs:
         make release RELEASE=1 STATIC=1 TARGET_ARCH=aarch64
 
     - name: Upload release bundle artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: cb_linux_aarch64
         path: dist
@@ -72,7 +72,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install crystal
       uses: crystal-lang/install-crystal@v1
@@ -95,7 +95,7 @@ jobs:
         make release RELEASE=1 STATIC_LIBS=1
 
     - name: Upload release bundle artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: cb_macos_arm64
         path: dist
@@ -110,21 +110,21 @@ jobs:
 
     - name: Download cb_linux_amd64.zip artifact
       id: download_linux_amd64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: cb_linux_amd64
         path: dist-linux-amd64
 
     - name: Download cb_linux_aarch64.zip artifact
       id: download_linux_aarch64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: cb_linux_aarch64
         path: dist-linux-aarch64
 
     - name: Download cb_macos_arm64.zip artifact
       id: download_macos_arm64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: cb_macos_arm64
         path: dist-macos-arm64


### PR DESCRIPTION
CI and release runs are emitting warnings that several actions
target Node.js 20, which GitHub is now forcing to run on Node.js
24. We bump the flagged actions to their latest major versions:
checkout v5, upload/download-artifact v5, setup-qemu-action v4,
and setup-buildx-action v4.

Also pins the DeterminateSystems nix actions in CI to release
tags (v22, v14) instead of tracking @main, which gives us more
predictable behavior across runs.
